### PR TITLE
Add support for multiple contexts

### DIFF
--- a/lib/feeb/db/local_state.ex
+++ b/lib/feeb/db/local_state.ex
@@ -14,6 +14,9 @@ defmodule Feeb.DB.LocalState do
          }
 
   def set_current_context(context, shard_id) do
+    if not context_exists?({context, shard_id}),
+      do: raise("Attempted to set a context that doesn't exist: #{inspect({context, shard_id})}")
+
     Process.put(:feebdb_current_context, {context, shard_id})
   end
 
@@ -64,4 +67,10 @@ defmodule Feeb.DB.LocalState do
     new_state = Map.drop(state, [{context, shard_id}])
     Process.put(:feebdb_state, new_state)
   end
+
+  defp context_exists?({_context, _shard_id} = key),
+    do: context_exists?(Process.get(:feebdb_state, %{}), key)
+
+  defp context_exists?(state, {_context, _shard_id} = key),
+    do: Map.has_key?(state, key)
 end

--- a/lib/feeb/db/local_state.ex
+++ b/lib/feeb/db/local_state.ex
@@ -1,0 +1,67 @@
+defmodule Feeb.DB.LocalState do
+  @moduledoc """
+  This module is responsible for managing Process state.
+  """
+
+  require Logger
+
+  @typep entry :: %{
+           context: atom(),
+           shard_id: integer(),
+           manager_pid: pid(),
+           repo_pid: pid(),
+           access_type: :read | :write
+         }
+
+  def set_current_context(context, shard_id) do
+    Process.put(:feebdb_current_context, {context, shard_id})
+  end
+
+  def unset_current_context do
+    Process.put(:feebdb_current_context, nil)
+  end
+
+  @spec get_current_context!() :: entry
+  def get_current_context! do
+    {context, shard_id} = Process.get(:feebdb_current_context) || raise "Current context not set"
+    state = Process.get(:feebdb_state)
+    Map.fetch!(state, {context, shard_id})
+  end
+
+  def add_entry(context, shard_id, {manager_pid, repo_pid, access_type}) do
+    true = is_pid(manager_pid)
+    true = is_pid(repo_pid)
+    true = access_type in [:read, :write]
+
+    entry = %{
+      context: context,
+      shard_id: shard_id,
+      manager_pid: manager_pid,
+      repo_pid: repo_pid,
+      access_type: access_type
+    }
+
+    key = {context, shard_id}
+
+    feebdb_state = Process.get(:feebdb_state, %{})
+
+    if Map.has_key?(feebdb_state, key),
+      do: Logger.warning("Adding LocalState entry to a key that already exists: #{inspect(key)}")
+
+    new_state = Map.put(feebdb_state, {context, shard_id}, entry)
+
+    Process.put(:feebdb_state, new_state)
+  end
+
+  def remove_entry(context, shard_id) do
+    state = Process.get(:feebdb_state) || raise "No LocalState found"
+
+    if not Map.has_key?(state, {context, shard_id}) do
+      "Attempted to delete #{inspect({context, shard_id})} from State but it no longer exists"
+      |> Logger.warning()
+    end
+
+    new_state = Map.drop(state, [{context, shard_id}])
+    Process.put(:feebdb_state, new_state)
+  end
+end

--- a/test/db/db_test.exs
+++ b/test/db/db_test.exs
@@ -1,18 +1,19 @@
 defmodule Feeb.DBTest do
   use Test.Feeb.DBCase, async: true
   alias Feeb.DB, as: DB
+  alias Feeb.DB.LocalState
 
   @context :test
-  @process_keys [:repo_pid, :manager_pid]
 
   describe "begin/3" do
     test "initiates a write transaction", %{shard_id: shard_id, db: db} do
       assert :ok == DB.begin(@context, shard_id, :write)
 
-      # The environment was set up:
-      assert_proc_state_exists()
-      state = get_proc_state()
-
+      # The environment was set up
+      state = LocalState.get_current_context!()
+      assert state.context == @context
+      assert state.shard_id == shard_id
+      assert state.access_type == :write
       assert Process.alive?(state.manager_pid)
       assert Process.alive?(state.repo_pid)
 
@@ -40,8 +41,10 @@ defmodule Feeb.DBTest do
       assert :ok == DB.begin(@context, shard_id, :read)
 
       # The environment was set up:
-      assert_proc_state_exists()
-      state = get_proc_state()
+      state = LocalState.get_current_context!()
+      assert state.context == @context
+      assert state.shard_id == shard_id
+      assert state.access_type == :read
 
       # Manager has correct data
       m_state = :sys.get_state(state.manager_pid)
@@ -76,10 +79,14 @@ defmodule Feeb.DBTest do
     test "finishes a transaction", %{shard_id: shard_id} do
       # First we start a transaction
       assert :ok == DB.begin(@context, shard_id, :write)
-      assert_proc_state_exists()
+
+      # LocalState exists
+      state = LocalState.get_current_context!()
+      assert state.context == @context
+      assert state.shard_id == shard_id
+      assert state.access_type == :write
 
       # Naturally repo and manager are alive
-      state = get_proc_state()
       assert Process.alive?(state.manager_pid)
       assert Process.alive?(state.repo_pid)
 
@@ -87,7 +94,13 @@ defmodule Feeb.DBTest do
       assert :ok == DB.commit()
 
       # Corresponding environment no longer exists
-      refute_proc_state_exists()
+      assert_raise RuntimeError, fn ->
+        LocalState.get_current_context!()
+      end
+
+      # More specifically, we can assert the state was removed from internal variables
+      refute Process.get(:feebdb_current_context)
+      assert Process.get(:feebdb_state) == %{}
 
       # Repo and Manager are still alive after the transaction
       assert Process.alive?(state.manager_pid)
@@ -131,19 +144,5 @@ defmodule Feeb.DBTest do
         DB.one({:friends, :get_all})
       end
     end
-  end
-
-  defp get_proc_state do
-    @process_keys
-    |> Enum.map(fn key -> {key, Process.get(key)} end)
-    |> Map.new()
-  end
-
-  defp assert_proc_state_exists do
-    Enum.each(@process_keys, fn key -> assert Process.get(key) end)
-  end
-
-  defp refute_proc_state_exists do
-    Enum.each(@process_keys, fn key -> refute Process.get(key) end)
   end
 end

--- a/test/db/local_state_test.exs
+++ b/test/db/local_state_test.exs
@@ -108,14 +108,30 @@ defmodule Feeb.DB.LocalStateTest do
 
   describe "set_current_context/2" do
     test "updates the Process state" do
+      # Initially, nothing exists in `current_context` even after we add a context entry
+      LocalState.add_entry(:context, 1, {self(), self(), :read})
+      refute current_context_var()
+
+      # The context will only exist in `current_context` after calling `set_current_context/2`
       LocalState.set_current_context(:context, 1)
       assert current_context_var() == {:context, 1}
+    end
+
+    test "raises when setting a context that doesn't exist in the state" do
+      %{message: error} =
+        assert_raise RuntimeError, fn ->
+          # This will raise because there is no corresponding entry in the `feebdb_state`
+          LocalState.set_current_context(:context, 1)
+        end
+
+      assert error == "Attempted to set a context that doesn't exist: {:context, 1}"
     end
   end
 
   describe "unset_current_context/0" do
     test "unsets the Process state" do
       # There is something set as current context
+      LocalState.add_entry(:context, 1, {self(), self(), :read})
       LocalState.set_current_context(:context, 1)
       assert current_context_var()
 

--- a/test/db/local_state_test.exs
+++ b/test/db/local_state_test.exs
@@ -1,0 +1,130 @@
+defmodule Feeb.DB.LocalStateTest do
+  use ExUnit.Case, async: true
+  import ExUnit.CaptureLog
+  alias Feeb.DB.LocalState
+
+  describe "add_entry/3" do
+    test "adds a new entry" do
+      # Initially, the `feebdb_state` is empty
+      refute state_var()
+
+      # Add an entry to the state
+      LocalState.add_entry(:context, 1, {self(), self(), :write})
+
+      assert %{{:context, 1} => entry} = state_var()
+      assert entry.context == :context
+      assert entry.shard_id == 1
+      assert entry.manager_pid == self()
+      assert entry.repo_pid == self()
+      assert entry.access_type == :write
+    end
+
+    test "supports multiple concurrent entries" do
+      # Initially, the `feebdb_state` is empty
+      refute state_var()
+
+      # Add several entries to the state
+      LocalState.add_entry(:context, 1, {self(), self(), :read})
+      LocalState.add_entry(:context, 2, {self(), self(), :write})
+      LocalState.add_entry(:context, 3, {self(), self(), :write})
+      LocalState.add_entry(:other_context, 1, {self(), self(), :write})
+
+      state = state_var()
+      assert Enum.find(state, fn {key, _} -> key == {:context, 1} end)
+      assert Enum.find(state, fn {key, _} -> key == {:context, 2} end)
+      assert Enum.find(state, fn {key, _} -> key == {:context, 3} end)
+      assert Enum.find(state, fn {key, _} -> key == {:other_context, 1} end)
+    end
+
+    test "warns if the entry already exists" do
+      LocalState.add_entry(:context, 1, {self(), self(), :read})
+
+      log =
+        capture_log(fn ->
+          # Repeated entry
+          LocalState.add_entry(:context, 1, {self(), self(), :read})
+        end)
+
+      assert log =~ "[warning] Adding LocalState entry to a key that already exists"
+      assert log =~ "{:context, 1}"
+    end
+  end
+
+  describe "remove_entry/2" do
+    test "removes the entry" do
+      # Initially, the `feebdb_state` is empty
+      refute state_var()
+
+      # Add an entry to the state
+      LocalState.add_entry(:context, 1, {self(), self(), :write})
+      LocalState.add_entry(:context, 2, {self(), self(), :write})
+
+      # The entry can be found in the state var
+      assert %{{:context, 1} => _, {:context, 2} => _} = state_var()
+
+      # Remove one of the entries
+      LocalState.remove_entry(:context, 1)
+
+      # Only the other entry is found in the state var
+      assert %{{:context, 2} => _} = state_var()
+
+      # Which will be empty if we remove that one too
+      LocalState.remove_entry(:context, 2)
+      assert %{} == state_var()
+    end
+
+    test "warns if the entry doesn't exist" do
+      # Assume `feebdb_state` is an empty map
+      Process.put(:feebdb_state, %{})
+
+      log = capture_log(fn -> LocalState.remove_entry(:context, 1) end)
+      assert log =~ "[warning] Attempted to delete {:context, 1} from State but it no longer exists"
+    end
+  end
+
+  describe "get_current_context!/0" do
+    test "returns the current context when set" do
+      # There is something set as current context
+      LocalState.add_entry(:context, 1, {self(), self(), :read})
+      LocalState.set_current_context(:context, 1)
+
+      state = LocalState.get_current_context!()
+      assert state.context == :context
+      assert state.shard_id == 1
+      assert state.manager_pid == self()
+      assert state.repo_pid == self()
+      assert state.access_type == :read
+    end
+
+    test "raises if no current context is set" do
+      %{message: error} =
+        assert_raise RuntimeError, fn ->
+          LocalState.get_current_context!()
+        end
+
+      assert error == "Current context not set"
+    end
+  end
+
+  describe "set_current_context/2" do
+    test "updates the Process state" do
+      LocalState.set_current_context(:context, 1)
+      assert current_context_var() == {:context, 1}
+    end
+  end
+
+  describe "unset_current_context/0" do
+    test "unsets the Process state" do
+      # There is something set as current context
+      LocalState.set_current_context(:context, 1)
+      assert current_context_var()
+
+      # Once unset, nothing else is defined in the context var
+      LocalState.unset_current_context()
+      refute current_context_var()
+    end
+  end
+
+  defp current_context_var, do: Process.get(:feebdb_current_context)
+  defp state_var, do: Process.get(:feebdb_state)
+end


### PR DESCRIPTION
The previous implementation was naive in the sense that it assumed an Erlang process would always connect to one and only one SQLite database. It is absolutely okay to connect to multiple different databases at once.

Naturally, you lose ACID properties when working across different databases, but within each database the operations are fully ACID.

I think the final API that I'm looking for is something like this:

```elixir

# This query will run in {:context, 1}
DB.begin(:context, 1, :write)
DB.insert(foo)

# This query will run in {:context, 2}  because `DB.begin/4` always overwrites the current context
DB.begin(:context, 2, :write)
DB.insert(foo)

# We are explicitly changing the context to `{:context, 1}`, so that's where this query will end up
DB.with_context(:context, 1)
DB.insert(foo)

# We have not changed the current context, so we are COMMITing `{:context, 1}`
DB.commit()

# And now we are COMMITing {:context, 2}
DB.with_context(:context, 2)
DB.commit()
```

Notice how `DB.with_context/2` shifts the current/active context future queries will use. I prefer that over having to specify the context in each query, since it greatly simplifies the Query API and we rarely need to change contexts (when compared to issuing database queries).