### PR TITLE
Generalize `initial_summary_for_context` on Migrator.Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Coverage Status](https://coveralls.io/repos/github/renatomassaro/FeebDB/badge.svg?branch=r/add-github-actions)](https://coveralls.io/github/renatomassaro/FeebDB?branch=main)
+[![Coverage Status](https://coveralls.io/repos/github/renatomassaro/FeebDB/badge.svg)](https://coveralls.io/github/renatomassaro/FeebDB?branch=main)
 
 # FeebDB
 

--- a/lib/feeb/db.ex
+++ b/lib/feeb/db.ex
@@ -148,6 +148,8 @@ defmodule Feeb.DB do
   end
 
   def all({_, domain, query_name}, bindings) do
+    bindings = if is_list(bindings), do: bindings, else: [bindings]
+
     case GenServer.call(get_pid!(), {:query, :all, {domain, query_name}, bindings}) do
       {:ok, rows} -> rows
       {:error, reason} -> raise reason

--- a/lib/feeb/db/migrator.ex
+++ b/lib/feeb/db/migrator.ex
@@ -47,18 +47,8 @@ defmodule Feeb.DB.Migrator do
 
     case setup_check_result do
       :ok ->
-        summary =
-          case Metadata.summarize_migrations(conn, context) do
-            %{} = m when map_size(m) == 0 ->
-              # TODO: Simplify this code
-              raise "No longer happens"
-              Metadata.initial_summary_for_context(context)
-
-            summary ->
-              summary
-          end
-
-        summary
+        conn
+        |> Metadata.summarize_migrations(context)
         |> Enum.reduce({:migrated, []}, fn {domain, v}, acc ->
           latest_version = get_latest_version(domain)
 


### PR DESCRIPTION
### Overview

1. Generate the values dynamically, based on the app configuration, instead of using hard-coded values.

2. Make this function private, since it is only used internally within that module.

3. Refactor Migrator to remove dead code (that used to call `initial_summary_for_context`).

### Incidental changes

- Refactor `DB.all/2` to accept single-parameter input that isn't a list.
- (Really) fix Coveralls branch in README.