### PR TITLE
Minor enhancements

### DIFF
--- a/lib/feeb/db/boot.ex
+++ b/lib/feeb/db/boot.ex
@@ -44,10 +44,19 @@ defmodule Feeb.DB.Boot do
     Migrator.setup()
 
     Enum.each(Config.contexts(), fn context ->
+      # Make sure the context is fully set up and ready to migrate shards
+      bootstrap_context(context)
+
+      # Migrate all shards (global, setup and application ones)
       :done = migrate_global_shards(context)
       :done = migrate_setup_shards(context)
       :done = migrate_application_shards(context)
     end)
+  end
+
+  defp bootstrap_context(context) do
+    context_data_path = "#{Config.data_dir()}/#{context.name}/"
+    File.mkdir_p(context_data_path)
   end
 
   defp migrate_global_shards(%{shard_type: :global} = context) do

--- a/test/db/repo_test.exs
+++ b/test/db/repo_test.exs
@@ -2,7 +2,7 @@ defmodule Feeb.DB.RepoTest do
   use Test.Feeb.DBCase, async: true
 
   alias GenServer, as: GS
-  alias Feeb.DB.{Repo, SQLite}
+  alias Feeb.DB.{Config, Repo, SQLite}
 
   @context :test
 
@@ -64,6 +64,21 @@ defmodule Feeb.DB.RepoTest do
       assert {:error, reason} = SQLite.raw(c, "DELETE FROM friends WHERE id = 1")
 
       assert reason =~ "attempt to write a readonly database"
+    end
+  end
+
+  describe "init/1" do
+    test "upon error, describes what went wrong (missing file)" do
+      shard_id = 123
+      db = Path.join(Config.data_dir(), "/not_a_context/#{shard_id}.db")
+
+      %{message: reason} =
+        assert_raise RuntimeError, fn ->
+          Repo.init({@context, 123, db, :readwrite})
+        end
+
+      assert reason =~ "Unable to open database"
+      assert reason =~ "Database file #{db} does not exist"
     end
   end
 

--- a/test/mix/task/migrate_test.exs
+++ b/test/mix/task/migrate_test.exs
@@ -8,9 +8,6 @@ defmodule Mix.Tasks.FeebDb.MigrateTest do
 
   describe "run/1" do
     test "migrates all shards", %{db: db} = ctx do
-      # We are using a `raw` DB, meaning it has nothing in it (100% fresh DB)
-      assert ctx.db_context == :raw
-
       # Every test has the capability to create its own shard, which is fully isolated from any
       # other test. As scuh, it's very common for me to not close/release/commit connections that
       # were opened during the test, resulting in these shards being effectively locked.
@@ -28,7 +25,10 @@ defmodule Mix.Tasks.FeebDb.MigrateTest do
       "#{Config.data_dir()}/**/*.db"
       |> Path.wildcard()
       |> Enum.reject(fn path -> path == db end)
-      |> Enum.map(fn path -> File.rm(path) end)
+      |> Enum.each(fn path -> File.rm(path) end)
+
+      # We are using a `raw` DB, meaning it has nothing in it (100% fresh DB)
+      assert ctx.db_context == :raw
 
       # Proof: users/sessions tables from lobby are not present:
       conn = open_conn(db)

--- a/test/mix/task/migrate_test.exs
+++ b/test/mix/task/migrate_test.exs
@@ -22,10 +22,7 @@ defmodule Mix.Tasks.FeebDb.MigrateTest do
       # In the future, it may make sense to refactor the `feeb_db.migrate` task to accept arguments
       # that specify a custom data directory. By using a custom data dir, I'd be able to "mock" the
       # shards without affecting other tests, and then we could use `async: true` here.
-      "#{Config.data_dir()}/**/*.db"
-      |> Path.wildcard()
-      |> Enum.reject(fn path -> path == db end)
-      |> Enum.each(fn path -> File.rm(path) end)
+      delete_all_shards_but_this_one(db)
 
       # We are using a `raw` DB, meaning it has nothing in it (100% fresh DB)
       assert ctx.db_context == :raw
@@ -51,6 +48,36 @@ defmodule Mix.Tasks.FeebDb.MigrateTest do
       assert {:ok, [["lobby", 2]]} == SQLite.raw(conn, "select * from __db_migrations_summary")
       SQLite.close(conn)
     end
+
+    test "sets up the shard directory (if one doesn't exist)", %{db: db} do
+      # Read comment on test above to understand why we need to do this
+      delete_all_shards_but_this_one(db)
+
+      # Create a `fake_context` that never existed until now
+      # Another reason why this suite must run with `async: false`: we are hijacking the config
+      original_contexts = Application.get_env(:feebdb, :contexts)
+      new_contexts = Map.put(original_contexts, :fake_context, %{shard_type: :dedicated})
+      Application.put_env(:feebdb, :contexts, new_contexts)
+
+      # The `fake_context` is there
+      assert Enum.find(Config.contexts(), &(&1.name == :fake_context))
+
+      # Before the migration, its directory did not exist
+      ctx_dir = Path.join(Config.data_dir(), "/fake_context")
+      File.rmdir(ctx_dir)
+      assert {:error, :enoent} = File.stat(ctx_dir)
+
+      # But it exists after the migration
+      assert :ok == MigrateTask.run([])
+      assert {:ok, %{type: :directory}} = File.stat(ctx_dir)
+    end
+  end
+
+  defp delete_all_shards_but_this_one(db) do
+    "#{Config.data_dir()}/**/*.db"
+    |> Path.wildcard()
+    |> Enum.reject(fn path -> path == db end)
+    |> Enum.each(fn path -> File.rm(path) end)
   end
 
   defp open_conn(db) do


### PR DESCRIPTION
Including:

- Use `Enum.each/2` instead of `Enum.map/2` in a particular function.
- Improved error message when unable to open a shard/database.
- If missing, create the context directory (instead of crashing) during boot.