### PR TITLE
Add support for virtual fields

### DIFF
--- a/lib/feeb/db/repo.ex
+++ b/lib/feeb/db/repo.ex
@@ -42,6 +42,10 @@ defmodule Feeb.DB.Repo do
           transaction_id: nil
         }
 
+        # `repo_config` is metadata that the Schema has access to when building virtual fields
+        repo_config = Map.drop(state, [:transaction_id, :conn])
+        Process.put(:repo_config, repo_config)
+
         {:ok, state, {:continue, :bootstrap}}
 
       {:error, :database_open_failed} ->

--- a/lib/feeb/db/schema.ex
+++ b/lib/feeb/db/schema.ex
@@ -246,7 +246,7 @@ defmodule Feeb.DB.Schema do
   end
 
   def from_row(model, fields, row) do
-    table_fields = get_table_fields(model)
+    table_fields = model.__cols__()
     fields_to_populate = if fields == [:*], do: table_fields, else: fields
 
     # TODO: Test this a lot...
@@ -330,10 +330,6 @@ defmodule Feeb.DB.Schema do
       |> Map.put(:errors, [{field, error} | schema.__meta__[:errors] || []])
 
     %{schema | __meta__: new_meta}
-  end
-
-  defp get_table_fields(model) do
-    :persistent_term.get({:db_table_fields, model})
   end
 
   def set_private(%{__private__: private} = schema, k, v) do

--- a/lib/feeb/db/schema.ex
+++ b/lib/feeb/db/schema.ex
@@ -367,10 +367,12 @@ defmodule Feeb.DB.Schema do
   defp add_virtual_fields(struct, [], _), do: struct
 
   defp add_virtual_fields(struct, virtual_fields, schema) do
+    repo_config = Process.get(:repo_config)
+
     Enum.reduce(virtual_fields, struct, fn field_name, acc ->
       {_, %{virtual: virtual_fn}, _} = Map.fetch!(schema, field_name)
 
-      value = apply(struct.__struct__, virtual_fn, [struct])
+      value = apply(struct.__struct__, virtual_fn, [struct, repo_config])
       Map.put(acc, field_name, value)
     end)
   end

--- a/priv/test/queries/test/friends.sql
+++ b/priv/test/queries/test/friends.sql
@@ -1,6 +1,9 @@
 -- :get_by_id
 select * from friends where id = ?;
 
+-- :get_by_name
+select * from friends where name = ?;
+
 -- :get_all
 select * from friends;
 

--- a/test/db/schema_test.exs
+++ b/test/db/schema_test.exs
@@ -6,6 +6,63 @@ defmodule DB.SchemaTest do
 
   @context :test
 
+  describe "generated: __schema__/0" do
+    # `__schema__/0` contains information about fields and their types
+    schema = Friend.__schema__()
+
+    assert Map.has_key?(schema, :id)
+    assert {id_type, id_opts, id_mod} = schema.id
+    assert id_type == Feeb.DB.Type.Integer
+    assert id_opts == %{}
+    assert id_mod == nil
+  end
+
+  describe "generated: __table__/0" do
+    assert :friends == Friend.__table__()
+    assert :all_types == AllTypes.__table__()
+  end
+
+  describe "generated: __context__/0" do
+    assert :test == Friend.__context__()
+    assert :test == AllTypes.__context__()
+  end
+
+  describe "generated: __cols__/0" do
+    test "includes all non-virtual fields in order" do
+      assert [:id, :name] == Friend.__cols__()
+
+      assert [
+               :boolean,
+               :boolean_nullable,
+               :string,
+               :string_nullable,
+               :integer,
+               :integer_nullable,
+               :atom,
+               :atom_nullable,
+               :uuid,
+               :uuid_nullable,
+               :datetime_utc,
+               :datetime_utc_nullable,
+               :datetime_utc_precision_second,
+               :datetime_utc_precision_millisecond,
+               :datetime_utc_precision_microsecond,
+               :datetime_utc_precision_default,
+               :map,
+               :map_nullable,
+               :map_keys_atom,
+               :map_keys_safe_atom,
+               :map_keys_string,
+               :map_keys_default,
+               :list,
+               :list_nullable,
+               :enum,
+               :enum_nullable,
+               :enum_safe_atom
+             ] == AllTypes.__cols__()
+    end
+  end
+
   describe "generated: __virtual_cols__/0" do
     test "includes all virtual fields" do
       assert [:divorce_count] == Friend.__virtual_cols__()

--- a/test/db/schema_test.exs
+++ b/test/db/schema_test.exs
@@ -65,7 +65,7 @@ defmodule DB.SchemaTest do
 
   describe "generated: __virtual_cols__/0" do
     test "includes all virtual fields" do
-      assert [:divorce_count] == Friend.__virtual_cols__()
+      assert [:divorce_count, :repo_config] == Friend.__virtual_cols__() |> Enum.sort()
       assert [] == AllTypes.__virtual_cols__()
     end
   end
@@ -101,11 +101,26 @@ defmodule DB.SchemaTest do
 
       ross = DB.one({:friends, :get_by_name}, "Ross")
       phoebe = DB.one({:friends, :get_by_name}, "Phoebe")
+      rachel = DB.one({:friends, :get_by_name}, "Rachel")
       monica = DB.one({:friends, :get_by_name}, "Monica")
 
       assert ross.divorce_count == 3
       assert phoebe.divorce_count == 1
+      assert rachel.divorce_count == 1
       assert monica.divorce_count == 0
+
+      expected_repo_config =
+        %{
+          context: @context,
+          shard_id: shard_id,
+          mode: :readonly,
+          path: DB.Repo.get_path(@context, shard_id)
+        }
+
+      assert ross.repo_config == expected_repo_config
+      assert phoebe.repo_config == expected_repo_config
+      assert rachel.repo_config == expected_repo_config
+      assert monica.repo_config == expected_repo_config
     end
   end
 end

--- a/test/support/db/schemas/friend.ex
+++ b/test/support/db/schemas/friend.ex
@@ -7,12 +7,30 @@ defmodule Sample.Friend do
 
   @schema [
     {:id, :integer},
-    {:name, :string}
+    {:name, :string},
+    {:divorce_count, {:integer, virtual: :get_divorce_count}}
   ]
 
   def new(params) do
     params
     |> Schema.cast(:all)
     |> Schema.create()
+  end
+
+  def get_divorce_count(%{name: name}) do
+    case name do
+      "Ross" ->
+        3
+
+      # Did Phoebe get a second divorce in Las Vegas???
+      "Phoebe" ->
+        1
+
+      "Rachel" ->
+        1
+
+      _ ->
+        0
+    end
   end
 end

--- a/test/support/db/schemas/friend.ex
+++ b/test/support/db/schemas/friend.ex
@@ -8,7 +8,8 @@ defmodule Sample.Friend do
   @schema [
     {:id, :integer},
     {:name, :string},
-    {:divorce_count, {:integer, virtual: :get_divorce_count}}
+    {:divorce_count, {:integer, virtual: :get_divorce_count}},
+    {:repo_config, {:map, virtual: :get_repo_config}}
   ]
 
   def new(params) do
@@ -17,7 +18,10 @@ defmodule Sample.Friend do
     |> Schema.create()
   end
 
-  def get_divorce_count(%{name: name}) do
+  def get_repo_config(_row, repo_config),
+    do: repo_config
+
+  def get_divorce_count(%{name: name}, _) do
     case name do
       "Ross" ->
         3


### PR DESCRIPTION
Virtual fields always come in handy at some point!

The callback to build the virtual field receives two inputs: the row itself and `repo_config`, which contains metadata about the database/connection, including its `shard_id`. This is particularly useful if the application wants to include the `shard_id` _in_ the schema itself.