### PR TITLE
Make migrations atomic

### DIFF
--- a/priv/test/migrations/will_fail/1_partially_correct_migration.sql
+++ b/priv/test/migrations/will_fail/1_partially_correct_migration.sql
@@ -1,0 +1,7 @@
+-- The `CREATE TABLE` below works just fine
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY
+) STRICT;
+
+-- But this won't work, after all there's no `username` in the table
+CREATE INDEX users_username_idx ON users (username);

--- a/test/db/boot_test.exs
+++ b/test/db/boot_test.exs
@@ -14,7 +14,7 @@ defmodule Feeb.DB.BootTest do
   describe "boot" do
     @tag unit: true
     test "stores migrations in persistent term" do
-      assert [:crm, :erp, :events, :lobby, :test] ==
+      assert [:crm, :erp, :events, :lobby, :test, :will_fail] ==
                Migrator.get_all_migrations() |> Map.keys() |> Enum.sort()
     end
 

--- a/test/db/migrator_sync_test.exs
+++ b/test/db/migrator_sync_test.exs
@@ -1,0 +1,53 @@
+defmodule Feeb.Db.MigratorSyncTest do
+  # This is an `async: false` version of `Feeb.DB.MigratorTest` for specific tests
+  use Test.Feeb.DBCase, async: false
+
+  alias Feeb.DB.{Migrator, SQLite}
+
+  @moduletag db: :raw
+
+  describe "migrate/2" do
+    test "migrations are atomic (ACID)", %{db: db} do
+      # CONTEXT: Please read `priv/test/migrations/will_fail/1_partially_correct_migration.sql` for
+      # full context, but basically we are executing 2 DDL statements: a CREATE TABLE and a CREATE
+      # INDEX. The first will succeed while the second will fail. We need to ensure that the
+      # migration rolled back entirely (i.e. it was an "all or nothing" operation).
+      Test.Feeb.DB.delete_all_dbs_but_this_one(db)
+
+      {:ok, conn} = SQLite.open(db)
+      SQLite.raw!(conn, "PRAGMA synchronous=1")
+      assert [] == SQLite.raw!(conn, "pragma table_info(users)")
+
+      # Another reason why this suite must run with `async: false`: we are hijacking the config
+      original_contexts = Application.get_env(:feebdb, :contexts)
+      new_contexts = Map.put(original_contexts, :will_fail, %{shard_type: :dedicated})
+      Application.put_env(:feebdb, :contexts, new_contexts)
+
+      assert {:needs_migration, migrations} =
+               Migrator.get_migration_status(conn, :will_fail, :readwrite)
+
+      assert [] == SQLite.raw!(conn, "pragma table_info(users)")
+
+      # Attempt to migrate raised an error
+      %{term: {:error, reason}} =
+        assert_raise(MatchError, fn ->
+          Migrator.migrate(conn, migrations)
+        end)
+
+      assert reason =~ "no such column: username"
+
+      # NOTE: We need to re-open the connection because _technically_ we never really rolled back,
+      # instead we simply never COMMITted. That's fine and harmless for now, but in the future we
+      # would benefit from better error-handling. When that time comes, re-opening the connection
+      # will no longer be necessary.
+      SQLite.close(conn)
+      {:ok, conn} = SQLite.open(db)
+
+      # Even though `CREATE TABLE` succeeded, there's no table because `CREATE INDEX` failed
+      assert [] == SQLite.raw!(conn, "pragma table_info(users)")
+
+      # Resume the original contexts (other synchronous tests may be affected otherwise)
+      Application.put_env(:feebdb, :contexts, original_contexts)
+    end
+  end
+end

--- a/test/db/migrator_test.exs
+++ b/test/db/migrator_test.exs
@@ -110,7 +110,8 @@ defmodule Feeb.DB.MigratorTest do
       migrations = Migrator.calculate_all_migrations()
 
       # Mapped all the existing domains/contexts in the migrations folder
-      assert [:crm, :erp, :events, :lobby, :test] = migrations |> Map.keys() |> Enum.sort()
+      assert [:crm, :erp, :events, :lobby, :test, :will_fail] =
+               migrations |> Map.keys() |> Enum.sort()
 
       # There are multiple migrations in lobby
       assert Enum.count(migrations.lobby) == 2

--- a/test/support/db.ex
+++ b/test/support/db.ex
@@ -44,16 +44,42 @@ defmodule Test.Feeb.DB do
     Feeb.DB.raw!("delete from #{table} where id = #{rand}")
   end
 
+  @doc """
+  Every test has the capability to create its own shard, which is fully isolated from any other
+  test. As such, it's very common for me to not close/release/commit connections that were opened
+  during the test, resulting in these shards being effectively locked.
+
+  That's not a problem, since these shards are never to be used inside another test. However, when
+  triggering `feeb_db.migrate`, we end up migrating every shard that is in the data directory,
+  many of which are locked because the Repo has an open transaction.
+
+  As a workaround, I'm simply deleting every shard (except the one passed as argument), which is why
+  callers of this function need to run with `async: false`.
+
+  Note, however, that _even_ if I closed the connections from every test, the callers of this
+  function would probably have flakes if they were to run with `async: true`: it's possible (or,
+  rather, certain) that some test would have its shard migrated midway, causing inconsistencies or
+  unexpected locks.
+
+  In the future, it may make sense to refactor the `feeb_db.migrate` task to accept arguments that
+  specify a custom data directory. By using a custom data dir, I'd be able to "mock" the shards
+  without affecting other tests, and then we could use `async: true` in such tests.
+  """
+  def delete_all_dbs_but_this_one(db) do
+    "#{Config.data_dir()}/**/*.db"
+    |> Path.wildcard()
+    |> Enum.reject(fn path -> path == db end)
+    |> Enum.each(fn path -> File.rm(path) end)
+  end
+
   defp delete_all_dbs do
     path = test_dbs_path()
     false = String.contains?(path, "*")
     false = String.contains?(path, " ")
 
-    "#{path}/**/*.{db,db-shm,db-wal}"
+    "#{path}/**/*.db*"
     |> Path.wildcard()
-    |> Stream.each(fn path ->
-      File.rm(path)
-    end)
+    |> Stream.each(fn path -> File.rm(path) end)
     |> Stream.run()
   end
 end


### PR DESCRIPTION
If one of the migrations (or one of the commands inside the migration) failed to execute, the entire operation should roll back.