### PR TITLE
Add support for custom types

### DIFF
--- a/lib/feeb/db/type.ex
+++ b/lib/feeb/db/type.ex
@@ -9,4 +9,5 @@ defmodule Feeb.DB.Type do
   def get_module(:map), do: __MODULE__.Map
   def get_module(:list), do: __MODULE__.List
   def get_module(:enum), do: __MODULE__.Enum
+  def get_module(mod) when is_atom(mod), do: mod
 end

--- a/priv/test/feebdb_schemas.json
+++ b/priv/test/feebdb_schemas.json
@@ -1,1 +1,1 @@
-{"test":["Elixir.Sample.AllTypes","Elixir.Sample.Friend","Elixir.Sample.Post"]}
+{"test":["Elixir.Sample.AllTypes","Elixir.Sample.CustomTypes","Elixir.Sample.Friend","Elixir.Sample.Post"]}

--- a/priv/test/migrations/test/241108191351_custom_types.sql
+++ b/priv/test/migrations/test/241108191351_custom_types.sql
@@ -1,0 +1,3 @@
+CREATE TABLE custom_types (
+  typed_id INTEGER
+) STRICT;

--- a/priv/test/queries/test/custom_types.sql
+++ b/priv/test/queries/test/custom_types.sql
@@ -1,0 +1,2 @@
+-- :get_by_typed_id
+select * from custom_types where typed_id = ?;

--- a/test/db/boot_test.exs
+++ b/test/db/boot_test.exs
@@ -24,7 +24,7 @@ defmodule Feeb.DB.BootTest do
 
       # Test migrations rarely change and thus can be hard-coded here (string because it gets
       # formatted to 123_456_789_012 otherwise, which is hard to read).
-      expected_test_latest = "241020150400" |> String.to_integer()
+      expected_test_latest = "241108191351" |> String.to_integer()
       test_latest = Migrator.get_latest_version(:test)
 
       assert test_latest == expected_test_latest

--- a/test/db/migrator_sync_test.exs
+++ b/test/db/migrator_sync_test.exs
@@ -46,7 +46,7 @@ defmodule Feeb.Db.MigratorSyncTest do
       # Even though `CREATE TABLE` succeeded, there's no table because `CREATE INDEX` failed
       assert [] == SQLite.raw!(conn, "pragma table_info(users)")
 
-      # Resume the original contexts (other synchronous tests may be affected otherwise)
+      # Restore the original contexts (other synchronous tests may be affected otherwise)
       Application.put_env(:feebdb, :contexts, original_contexts)
     end
   end

--- a/test/db/migrator_sync_test.exs
+++ b/test/db/migrator_sync_test.exs
@@ -15,8 +15,6 @@ defmodule Feeb.Db.MigratorSyncTest do
       Test.Feeb.DB.delete_all_dbs_but_this_one(db)
 
       {:ok, conn} = SQLite.open(db)
-      SQLite.raw!(conn, "PRAGMA synchronous=1")
-      assert [] == SQLite.raw!(conn, "pragma table_info(users)")
 
       # Another reason why this suite must run with `async: false`: we are hijacking the config
       original_contexts = Application.get_env(:feebdb, :contexts)
@@ -25,8 +23,6 @@ defmodule Feeb.Db.MigratorSyncTest do
 
       assert {:needs_migration, migrations} =
                Migrator.get_migration_status(conn, :will_fail, :readwrite)
-
-      assert [] == SQLite.raw!(conn, "pragma table_info(users)")
 
       # Attempt to migrate raised an error
       %{term: {:error, reason}} =

--- a/test/db/type/custom_types/typed_id_test.exs
+++ b/test/db/type/custom_types/typed_id_test.exs
@@ -1,0 +1,30 @@
+defmodule Feeb.DB.Type.CustomTypes.TypedIDTest do
+  use Test.Feeb.DBCase, async: true
+  alias Feeb.DB
+  alias Sample.CustomTypes
+  alias Sample.Types.TypedID
+
+  @context :test
+
+  describe "TypedID custom type" do
+    test "stores and loads correctly", %{shard_id: shard_id} do
+      params = CustomTypes.creation_params(%{typed_id: 50})
+      custom_types = CustomTypes.new(params)
+
+      # TypedID is cast as a struct
+      assert custom_types.typed_id == %TypedID{id: 50}
+
+      # It is dumped and loaded correctly
+      DB.begin(@context, shard_id, :write)
+      assert {:ok, db_custom_types} = DB.insert(custom_types)
+      assert db_custom_types.typed_id == %TypedID{id: 50}
+
+      # Value is stored as integer in the database
+      assert [[50]] == DB.raw!("select typed_id from custom_types")
+
+      # Reading it loads the type correctly
+      assert [row] = DB.all(CustomTypes)
+      assert row.typed_id == %TypedID{id: 50}
+    end
+  end
+end

--- a/test/mix/task/migrate_test.exs
+++ b/test/mix/task/migrate_test.exs
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.FeebDb.MigrateTest do
       assert :ok == MigrateTask.run([])
       assert {:ok, %{type: :directory}} = File.stat(ctx_dir)
 
-      # Resume the original contexts (other synchronous tests may be affected otherwise)
+      # Restore the original contexts (other synchronous tests may be affected otherwise)
       Application.put_env(:feebdb, :contexts, original_contexts)
     end
   end

--- a/test/support/db/schemas/custom_types.ex
+++ b/test/support/db/schemas/custom_types.ex
@@ -1,0 +1,25 @@
+defmodule Sample.CustomTypes do
+  use Feeb.DB.Schema
+  alias Feeb.DB.Schema
+  alias Sample.Types.TypedID
+
+  @context :test
+  @table :custom_types
+
+  @schema [
+    {:typed_id, TypedID}
+  ]
+
+  def new(params) do
+    params
+    |> Schema.cast(:all)
+    |> Schema.create()
+  end
+
+  def creation_params(overwrites \\ %{}) do
+    %{
+      typed_id: 1
+    }
+    |> Map.merge(overwrites)
+  end
+end

--- a/test/support/db/types/typed_id.ex
+++ b/test/support/db/types/typed_id.ex
@@ -1,0 +1,21 @@
+defmodule Sample.Types.TypedID do
+  @behaviour Feeb.DB.Type.Behaviour
+
+  defstruct [:id]
+
+  @impl true
+  def sqlite_type, do: :integer
+
+  @impl true
+  def cast!(v, _, _) when is_integer(v), do: %__MODULE__{id: v}
+
+  @impl true
+  def dump!(%__MODULE__{id: v}, _, _), do: v
+
+  @impl true
+  def load!(v, _, _) when is_integer(v), do: %__MODULE__{id: v}
+
+  defimpl String.Chars do
+    def to_string(%{id: id}), do: "#{id}"
+  end
+end


### PR DESCRIPTION
This PR enables application-defined types. As one example (which I'm using for testing), an application can create a "TypedID", which enforces a (typed) struct, thus allowing it to pattern-match against type-safe IDs.

With a similar implementation, one can have:

```elixir
def add_line_item(%Order.ID{} = order_id, %Invoice.ID{} = invoice_id)
```

instead of

```elixir
def add_line_item(order_id, invoice_id)
```