### PR TITLE
Add support for enqueuing requests when there are no available Repos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,8 +45,13 @@ jobs:
       - name: Check formatting
         run: mix format --check-formatted
 
-      - name: Test app
-        run: mix coveralls.github
+      - name: Quick tests
+        run: mix test
+
+      # It's important that the coverage comes from the full test suite (i.e. with `slow` tests)
+      # because these tests cover lines that were not covered by the quick tests.
+      - name: Full test suite + coverage
+        run: mix coveralls.github --include slow
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   linters:

--- a/lib/feeb/db.ex
+++ b/lib/feeb/db.ex
@@ -15,8 +15,8 @@ defmodule Feeb.DB do
   Starts a transaction.
 
   It will fetch (or create) the Repo.Manager for the corresponding {context, shard_id}, and it will
-  also fetch the Repo connection (upon availability; blocking). Once returned, the caller process
-  can perform requests against the shard.
+  also fetch the Repo connection (upon availability; blocking until a connection is made available).
+  Once returned, the caller process can perform requests against the shard.
 
   If `access_type` is `:env`, skip the set up process described above and rely on Context (Process
   state) instead.

--- a/lib/feeb/db.ex
+++ b/lib/feeb/db.ex
@@ -21,8 +21,10 @@ defmodule Feeb.DB do
   If `access_type` is `:env`, skip the set up process described above and rely on Context (Process
   state) instead.
   """
-  def begin(context, shard_id, access_type, transaction_type \\ :exclusive) do
-    setup_env(context, shard_id, access_type)
+  def begin(context, shard_id, access_type, opts \\ []) do
+    transaction_type = opts[:type] || :exclusive
+
+    setup_env(context, shard_id, access_type, opts)
     set_context(context, shard_id)
 
     # We can't BEGIN EXCLUSIVE in a read-only database
@@ -256,11 +258,11 @@ defmodule Feeb.DB do
   # Private
   ##################################################################################################
 
-  defp setup_env(context, shard_id, type) when type in [:write, :read] do
+  defp setup_env(context, shard_id, type, opts) when type in [:write, :read] do
     {:ok, manager_pid} = Repo.Manager.Registry.fetch_or_create(context, shard_id)
 
     # TODO: Handle busy
-    {:ok, repo_pid} = Repo.Manager.fetch_connection(manager_pid, type)
+    {:ok, repo_pid} = Repo.Manager.fetch_connection(manager_pid, type, opts)
 
     LocalState.add_entry(context, shard_id, {manager_pid, repo_pid, type})
   end

--- a/lib/feeb/db/repo/manager.ex
+++ b/lib/feeb/db/repo/manager.ex
@@ -56,7 +56,8 @@ defmodule Feeb.DB.Repo.Manager do
   end
 
   def fetch_connection(manager_pid, type, opts \\ []) when type in [:write, :read] do
-    GenServer.call(manager_pid, {:fetch, type, opts})
+    # Custom timeout information must be set via `:queue_timeout`; default is 2s.
+    GenServer.call(manager_pid, {:fetch, type, opts}, :infinity)
   end
 
   def release_connection(manager_pid, repo_pid) do

--- a/mix.exs
+++ b/mix.exs
@@ -11,6 +11,7 @@ defmodule Feeb.DB.Mixfile do
       description: description(),
       package: package(),
       deps: deps(),
+      aliases: aliases(),
       compilers: Mix.compilers(),
       test_coverage: [tool: ExCoveralls],
       elixirc_paths: elixirc_paths(Mix.env()),
@@ -19,7 +20,8 @@ defmodule Feeb.DB.Mixfile do
         "coveralls.html": :test,
         "coveralls.detail": :test,
         "coveralls.json": :test,
-        "coveralls.post": :test
+        "coveralls.post": :test,
+        "test.full": :test
       ],
       dialyzer: [plt_add_apps: [:mix]]
     ]
@@ -63,4 +65,12 @@ defmodule Feeb.DB.Mixfile do
   # Specifies which paths to compile per environment
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
+
+  defp aliases do
+    [
+      test: "test.quick",
+      "test.quick": "test --exclude slow",
+      "test.full": "test --include slow"
+    ]
+  end
 end

--- a/test/db/db_test.exs
+++ b/test/db/db_test.exs
@@ -7,7 +7,7 @@ defmodule Feeb.DBTest do
 
   @context :test
 
-  describe "begin/3" do
+  describe "begin/4" do
     test "initiates a write transaction", %{shard_id: shard_id, db: db} do
       assert :ok == DB.begin(@context, shard_id, :write)
 

--- a/test/db/db_test.exs
+++ b/test/db/db_test.exs
@@ -2,7 +2,7 @@ defmodule Feeb.DBTest do
   use Test.Feeb.DBCase, async: true
   alias Feeb.DB, as: DB
   alias Feeb.DB.LocalState
-  alias Sample.{AllTypes, CustomTypes, Post}
+  alias Sample.{AllTypes, CustomTypes, Friend, Post}
   alias Sample.Types.TypedID
 
   @context :test
@@ -65,6 +65,52 @@ defmodule Feeb.DBTest do
       DB.commit()
     end
 
+    test "multiple writes on the same shard are enqueued", %{shard_id: shard_id} do
+      task_fn = fn id ->
+        DB.begin(@context, shard_id, :write)
+
+        %{id: id, title: "Post #{id}", body: "Body #{id}"}
+        |> Post.new()
+        |> DB.insert!()
+
+        DB.commit()
+      end
+
+      # We'll try to concurrently insert 3 entries in the same shard
+      [
+        Task.async(fn -> task_fn.(1) end),
+        Task.async(fn -> task_fn.(2) end),
+        Task.async(fn -> task_fn.(3) end)
+      ]
+      |> Task.await_many()
+
+      # All 3 entries were inserted
+      DB.begin(@context, shard_id, :read)
+      assert [_, _, _] = DB.all(Post)
+    end
+
+    test "multiple reads on the same shard are enqueued", %{shard_id: shard_id} do
+      task_fn = fn id ->
+        DB.begin(@context, shard_id, :read)
+        result = DB.one({:friends, :get_by_id}, [id])
+        DB.commit()
+
+        result
+      end
+
+      # We concurrently performed 5 read operations in the same shard. Since there are only two
+      # available read Repos, some queueing was necessary
+      assert [%Friend{id: 1}, %Friend{id: 2}, %Friend{id: 3}, %Friend{id: 4}, %Friend{id: 5}] =
+               [
+                 Task.async(fn -> task_fn.(1) end),
+                 Task.async(fn -> task_fn.(2) end),
+                 Task.async(fn -> task_fn.(3) end),
+                 Task.async(fn -> task_fn.(4) end),
+                 Task.async(fn -> task_fn.(5) end)
+               ]
+               |> Task.await_many()
+    end
+
     test "supports multiple contexts in the same process" do
       {:ok, test_shard_1, _} = Test.Feeb.DB.Setup.new_test_db(:test)
       {:ok, test_shard_2, _} = Test.Feeb.DB.Setup.new_test_db(:test)
@@ -94,18 +140,6 @@ defmodule Feeb.DBTest do
       refute test_entry_2.manager_pid == raw_entry_1.manager_pid
       refute test_entry_1.repo_pid == test_entry_2.repo_pid
       refute test_entry_2.repo_pid == raw_entry_1.repo_pid
-    end
-
-    @tag capture_log: true
-    test "fails on parallel calls", %{shard_id: shard_id} do
-      # Write
-      assert :ok == DB.begin(@context, shard_id, :write)
-      assert_raise MatchError, fn -> DB.begin(@context, shard_id, :write) end
-
-      # Read
-      assert :ok == DB.begin(@context, shard_id, :read)
-      assert :ok == DB.begin(@context, shard_id, :read)
-      assert_raise MatchError, fn -> DB.begin(@context, shard_id, :read) end
     end
   end
 

--- a/test/db/repo/manager_test.exs
+++ b/test/db/repo/manager_test.exs
@@ -57,7 +57,7 @@ defmodule Feeb.DB.Repo.ManagerTest do
       spawn_pid =
         spawn(fn ->
           send(test_pid, :spawn_initiated)
-          Manager.fetch_connection(manager, :write, queue_timeout: 999_999)
+          Manager.fetch_connection(manager, :write, queue_timeout: :infinity)
         end)
 
       # Block just to give enough time for the `spawn` block to try fetching the connection

--- a/test/db/repo/manager_test.exs
+++ b/test/db/repo/manager_test.exs
@@ -171,7 +171,7 @@ defmodule Feeb.DB.Repo.ManagerTest do
       # for a connection
       manager_state = :sys.get_state(manager)
       assert :queue.len(manager_state.write_queue) == 1
-      assert :queue.any(fn {{pid, _}, _, _} -> pid == spawn_pid end, manager_state.write_queue)
+      assert :queue.any(fn {{pid, _}, _, _, _} -> pid == spawn_pid end, manager_state.write_queue)
     end
 
     test "handles when the *only* caller waiting for a connection dies", %{manager: manager} do
@@ -187,7 +187,7 @@ defmodule Feeb.DB.Repo.ManagerTest do
       %{write_queue: queue_before, write_1: write_1_before} = :sys.get_state(manager)
       assert write_1_before.busy?
       assert :queue.len(queue_before) == 1
-      assert :queue.any(fn {{pid, _}, _, _} -> pid == spawn_pid end, queue_before)
+      assert :queue.any(fn {{pid, _}, _, _, _} -> pid == spawn_pid end, queue_before)
 
       # The caller has died but is still waiting for a connection, since we are not monitoring it
       # inside Repo.Manager
@@ -221,8 +221,8 @@ defmodule Feeb.DB.Repo.ManagerTest do
       # Initially, both `spawn_pid_1` and `spawn_pid_2` are in the queue (in that order)
       %{write_queue: queue_before} = :sys.get_state(manager)
       assert :queue.len(queue_before) == 2
-      assert {{:value, {{^spawn_pid_1, _}, _, _}}, next_queue} = :queue.out(queue_before)
-      assert {{:value, {{^spawn_pid_2, _}, _, _}}, _} = :queue.out(next_queue)
+      assert {{:value, {{^spawn_pid_1, _}, _, _, _}}, next_queue} = :queue.out(queue_before)
+      assert {{:value, {{^spawn_pid_2, _}, _, _, _}}, _} = :queue.out(next_queue)
 
       # We'll kill spawn_pid_1, which as seen above is the first element in the queue
       Process.exit(spawn_pid_1, :kill)

--- a/test/db/stress_test.exs
+++ b/test/db/stress_test.exs
@@ -1,0 +1,40 @@
+defmodule Feeb.DB.StressTest do
+  use Test.Feeb.DBCase, async: true
+
+  alias Sample.Post
+
+  @moduletag timeout: :infinity
+  @moduletag :slow
+
+  @context :test
+
+  test "100k concurrent writes in the same shard at the same time", %{shard_id: shard_id} do
+    # Approximate time it takes for this test to complete in my machine:
+    # 10k:  0.8s
+    # 100k: 7.2s
+    # 1M:   72.6s
+    # It's interesting to see it grows linearly.
+
+    task_fn = fn id ->
+      DB.begin(@context, shard_id, :write,
+        queue_warning_threshold: :infinity,
+        queue_timeout: :infinity
+      )
+
+      %{id: id, title: "Post #{id}", body: "Body #{id}"}
+      |> Post.new()
+      |> DB.insert!()
+
+      DB.commit()
+    end
+
+    # Attempt to perform 100k writes concurrently
+    1..100_000
+    |> Task.async_stream(fn idx -> task_fn.(idx) end)
+    |> Stream.run()
+
+    # All 100k entries were inserted
+    DB.begin(@context, shard_id, :read)
+    assert [[100_000]] == DB.raw!("select count(*) from posts")
+  end
+end

--- a/test/support/case/db.ex
+++ b/test/support/case/db.ex
@@ -11,6 +11,8 @@ defmodule Test.Feeb.DBCase do
 
       alias Test.Setup
       alias Test.Samples
+
+      alias Feeb.DB
     end
   end
 

--- a/test/support/db/setup.ex
+++ b/test/support/db/setup.ex
@@ -37,6 +37,10 @@ defmodule Test.Feeb.DB.Setup do
   end
 
   defp gen_shard_id do
-    :rand.uniform() |> Kernel.*(1_000_000) |> trunc()
+    # And here I am thinking we wouldn't ever hit different tests with the same shard_id. I was very
+    # wrong. This happened when the test suite had 180 tests. Hence the usage of `strong_rand_bytes`
+    :crypto.strong_rand_bytes(8)
+    |> :binary.decode_unsigned()
+    |> rem(1_000_000)
   end
 end

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -1,4 +1,26 @@
 defmodule Test.Utils do
   def date_diff_ms(date_a, date_b),
     do: DateTime.diff(date_a, date_b, :millisecond)
+
+  @doc """
+  Spawns a process and blocks waiting for it to start. Might sleep for an `additional_sleep` amount
+  of time (in ms). Returns the spawned pid once it's been spawned.
+  """
+  def spawn_and_wait(fun, additional_sleep \\ 10) do
+    test_pid = self()
+
+    spawn_pid =
+      spawn(fn ->
+        send(test_pid, :spawn_ok)
+        fun.()
+      end)
+
+    receive do
+      :spawn_ok ->
+        :timer.sleep(additional_sleep)
+        :ok
+    end
+
+    spawn_pid
+  end
 end


### PR DESCRIPTION
Each shard can have at most 1 write Repo and at most 2 read Repos.

The "single-write Repo" is a fundamental constraint of SQLite and will never change[0]. The "at most 2 read Repos" bit is arbitrary from my part and can be tweaked in the future (for example, to allow a configurable number of read Repos) -- it's fine to have multiple concurrent readers (in WAL mode, which is the journaling mode FeebDB operates in).

Previously, when the requested connection could not be fetched (because they were already in use by another process), the Repo.Manager would simply return a `:busy` atom.

Now, it will block the caller (at `Repo.Manager.fetch_connection/2`) and return a response once a connection is made available.

### TODOs

- [x] Timeout timer
- [x] Configurable latency warning threshold 
- [x] Investigate flakes
  - `mix test --seed 323658`
  - `mix test --seed 314104`

---

[0] - Well, there is `BEGIN CONCURRENT` which looks promising... but for the time being, it doesn't make sense to support concurrent write processes to the same shard.