### PR TITLE
Improved monitoring of leased connections

### DIFF
--- a/lib/feeb/db/repo.ex
+++ b/lib/feeb/db/repo.ex
@@ -17,11 +17,8 @@ defmodule Feeb.DB.Repo do
   # Callbacks
 
   # Client API
-  def start_link({_, _, _, _} = repo_args),
-    do: start_link(Tuple.append(repo_args, nil))
-
-  def start_link({_, _, _, _, _} = all_args),
-    do: GenServer.start_link(__MODULE__, all_args)
+  def start_link({_, _, _, _, _} = args),
+    do: GenServer.start_link(__MODULE__, args)
 
   def close(pid),
     do: GenServer.call(pid, {:close})

--- a/lib/feeb/db/repo/manager.ex
+++ b/lib/feeb/db/repo/manager.ex
@@ -158,7 +158,6 @@ defmodule Feeb.DB.Repo.Manager do
 
         # If `caller_pid` had a normal death, emit a warning so they remember to properly release
         # the connection. This is likely an application bug
-
         if reason == :normal do
           ("Process #{inspect(caller_pid)} died with :normal reason without releasing the " <>
              "#{key} connection #{inspect(repo_pid)} -- maybe you forgot to commit/rollback?")

--- a/lib/feeb/db/repo/manager.ex
+++ b/lib/feeb/db/repo/manager.ex
@@ -285,7 +285,7 @@ defmodule Feeb.DB.Repo.Manager do
     db_path = Repo.get_path(context, shard_id)
 
     # REVIEW: Do I really want to link both genservers?
-    case Repo.start_link({context, shard_id, db_path, mode}) do
+    case Repo.start_link({context, shard_id, db_path, mode, self()}) do
       {:ok, repo_pid} ->
         log(:info, "Established and fetched #{mode} connection", state)
 

--- a/lib/feeb/db/repo/manager.ex
+++ b/lib/feeb/db/repo/manager.ex
@@ -43,7 +43,7 @@ defmodule Feeb.DB.Repo.Manager do
   alias Feeb.DB.Repo
 
   # Time (in ms) after which we should issue a warning for requests waiting in the queue. This can
-  # be override with the `:queue_warning_threshold` key in `opts` (accepts `:infinity`).
+  # be overriden with the `:queue_warning_threshold` key in `opts` (accepts `:infinity`).
   @default_queue_warning_threshold 50
 
   # Default time (in ms) that a request can wait for an available connection. This can be overriden

--- a/lib/feeb/db/repo/manager.ex
+++ b/lib/feeb/db/repo/manager.ex
@@ -184,7 +184,6 @@ defmodule Feeb.DB.Repo.Manager do
         fetch_available_connection(state, :write_1, caller)
 
       state.write_1.busy? ->
-        # TODO: Instead of polling, notify caller once available
         {:busy, state}
     end
   end
@@ -208,7 +207,6 @@ defmodule Feeb.DB.Repo.Manager do
         fetch_available_connection(state, :read_2, caller)
 
       state.read_2.busy? ->
-        # TODO: Instead of polling, notify caller once available
         {:busy, state}
     end
   end

--- a/lib/feeb/db/repo/manager/repo_entry.ex
+++ b/lib/feeb/db/repo/manager/repo_entry.ex
@@ -1,0 +1,43 @@
+defmodule Feeb.DB.Repo.Manager.RepoEntry do
+  @enforce_keys [:busy?]
+  defstruct [:pid, :caller_pid, :timer_ref, :monitor_ref, busy?: false]
+
+  @doc """
+  Creates an initial RepoEntry
+  """
+  def on_start, do: %__MODULE__{busy?: false}
+
+  @doc """
+  Set a Repo pid to an initial RepoEntry
+  """
+  def on_establish(%__MODULE__{pid: nil, busy?: false}, repo_pid),
+    do: %__MODULE__{pid: repo_pid, busy?: false}
+
+  @doc """
+  Lease a Repo (in an established RepoEntry) to a particular caller
+  """
+  def on_acquire(%__MODULE__{pid: pid, busy?: false}, {caller_pid, monitor_ref, timer_ref}) do
+    %__MODULE__{
+      pid: pid,
+      busy?: true,
+      caller_pid: caller_pid,
+      monitor_ref: monitor_ref,
+      timer_ref: timer_ref
+    }
+  end
+
+  @doc """
+  Release the Repo in a leased RepoEntry
+  """
+  def on_release(%__MODULE__{pid: repo_pid}) do
+    %__MODULE__{
+      pid: repo_pid,
+      busy?: false
+    }
+  end
+
+  @doc """
+  Remove the Repo from an initial, established or released RepoEntry.
+  """
+  def on_close(%__MODULE__{pid: _, busy?: false}), do: on_start()
+end

--- a/lib/feeb/db/repo/repo_config.ex
+++ b/lib/feeb/db/repo/repo_config.ex
@@ -1,0 +1,17 @@
+defmodule Feeb.DB.Repo.RepoConfig do
+  @struct_keys [:context, :shard_id, :mode, :path]
+  @enforce_keys @struct_keys
+  defstruct @struct_keys
+
+  @doc """
+  Builds the initial (and only) RepoConfig from the Repo state
+  """
+  def from_state(state) do
+    %__MODULE__{
+      context: state.context,
+      shard_id: state.shard_id,
+      mode: state.mode,
+      path: state.path
+    }
+  end
+end

--- a/test/db/repo/manager/registry_test.exs
+++ b/test/db/repo/manager/registry_test.exs
@@ -16,9 +16,9 @@ defmodule Feeb.DB.Repo.Manager.RegistryTest do
       manager_state = :sys.get_state(manager_pid)
       assert manager_state.context == :test
       assert manager_state.shard_id == shard_id
-      assert manager_state.write_1 == %{pid: nil, busy?: false}
-      assert manager_state.read_1 == %{pid: nil, busy?: false}
-      assert manager_state.read_2 == %{pid: nil, busy?: false}
+      assert manager_state.write_1 == %{pid: nil, busy?: false, caller_pid: nil, monitor_ref: nil}
+      assert manager_state.read_1 == %{pid: nil, busy?: false, caller_pid: nil, monitor_ref: nil}
+      assert manager_state.read_2 == %{pid: nil, busy?: false, caller_pid: nil, monitor_ref: nil}
 
       # The manager PID is stored in the ETS registry table
       assert [{{:test, shard_id}, manager_pid}] == :ets.lookup(@ets_table_name, {:test, shard_id})

--- a/test/db/repo/manager/registry_test.exs
+++ b/test/db/repo/manager/registry_test.exs
@@ -16,9 +16,31 @@ defmodule Feeb.DB.Repo.Manager.RegistryTest do
       manager_state = :sys.get_state(manager_pid)
       assert manager_state.context == :test
       assert manager_state.shard_id == shard_id
-      assert manager_state.write_1 == %{pid: nil, busy?: false, caller_pid: nil, monitor_ref: nil}
-      assert manager_state.read_1 == %{pid: nil, busy?: false, caller_pid: nil, monitor_ref: nil}
-      assert manager_state.read_2 == %{pid: nil, busy?: false, caller_pid: nil, monitor_ref: nil}
+
+      # TODO: Assert against initial struct instead
+      assert manager_state.write_1 == %{
+               pid: nil,
+               busy?: false,
+               caller_pid: nil,
+               monitor_ref: nil,
+               timer_ref: nil
+             }
+
+      assert manager_state.read_1 == %{
+               pid: nil,
+               busy?: false,
+               caller_pid: nil,
+               monitor_ref: nil,
+               timer_ref: nil
+             }
+
+      assert manager_state.read_2 == %{
+               pid: nil,
+               busy?: false,
+               caller_pid: nil,
+               monitor_ref: nil,
+               timer_ref: nil
+             }
 
       # The manager PID is stored in the ETS registry table
       assert [{{:test, shard_id}, manager_pid}] == :ets.lookup(@ets_table_name, {:test, shard_id})

--- a/test/db/repo/manager/registry_test.exs
+++ b/test/db/repo/manager/registry_test.exs
@@ -1,6 +1,7 @@
 defmodule Feeb.DB.Repo.Manager.RegistryTest do
   use Test.Feeb.DBCase, async: true
   import ExUnit.CaptureLog
+  alias Feeb.DB.Repo.Manager
   alias Feeb.DB.Repo.Manager.Registry
 
   @ets_table_name :feebdb_manager_registry
@@ -17,30 +18,9 @@ defmodule Feeb.DB.Repo.Manager.RegistryTest do
       assert manager_state.context == :test
       assert manager_state.shard_id == shard_id
 
-      # TODO: Assert against initial struct instead
-      assert manager_state.write_1 == %{
-               pid: nil,
-               busy?: false,
-               caller_pid: nil,
-               monitor_ref: nil,
-               timer_ref: nil
-             }
-
-      assert manager_state.read_1 == %{
-               pid: nil,
-               busy?: false,
-               caller_pid: nil,
-               monitor_ref: nil,
-               timer_ref: nil
-             }
-
-      assert manager_state.read_2 == %{
-               pid: nil,
-               busy?: false,
-               caller_pid: nil,
-               monitor_ref: nil,
-               timer_ref: nil
-             }
+      assert manager_state.write_1 == Manager.RepoEntry.on_start()
+      assert manager_state.read_1 == Manager.RepoEntry.on_start()
+      assert manager_state.read_2 == Manager.RepoEntry.on_start()
 
       # The manager PID is stored in the ETS registry table
       assert [{{:test, shard_id}, manager_pid}] == :ets.lookup(@ets_table_name, {:test, shard_id})

--- a/test/db/repo/manager_test.exs
+++ b/test/db/repo/manager_test.exs
@@ -216,9 +216,7 @@ defmodule Feeb.DB.Repo.ManagerTest do
         spawn_and_wait(fn ->
           Manager.fetch_connection(manager, :write, queue_timeout: :infinity)
           send(test_pid, :got_connection)
-
-          # Keep this process alive until the end of the test
-          :timer.sleep(999_999)
+          block_forever()
         end)
 
       # Initially, both `spawn_pid_1` and `spawn_pid_2` are in the queue (in that order)
@@ -249,9 +247,7 @@ defmodule Feeb.DB.Repo.ManagerTest do
       request_pid =
         spawn_and_wait(fn ->
           Manager.fetch_connection(manager, :write)
-
-          # Keep this process alive until the test can end its execution
-          :timer.sleep(999_999)
+          block_forever()
         end)
 
       # The Repo.Manager currently has an active write_1 connection leased to `request_pid`
@@ -276,14 +272,14 @@ defmodule Feeb.DB.Repo.ManagerTest do
       request_pid =
         spawn_and_wait(fn ->
           Manager.fetch_connection(manager, :write)
-          :timer.sleep(999_999)
+          block_forever()
         end)
 
       queued_request_pid =
         spawn_and_wait(fn ->
           # This guy is waiting for `request_pid` to release the connection
           Manager.fetch_connection(manager, :write)
-          :timer.sleep(999_999)
+          block_forever()
         end)
 
       # The write_1 connection is busy (leased to `request_pid`) and there is a non-empty queue

--- a/test/db/repo_test.exs
+++ b/test/db/repo_test.exs
@@ -23,7 +23,7 @@ defmodule Feeb.DB.RepoTest do
     @describetag skip_init: true
 
     test "in readwrite mode", %{shard_id: shard_id, db: db} do
-      assert {:ok, pid} = start_supervised({Repo, {@context, shard_id, db, :readwrite}})
+      assert {:ok, pid} = start_supervised({Repo, {@context, shard_id, db, :readwrite, nil}})
 
       state = :sys.get_state(pid)
       c = state.conn
@@ -48,7 +48,7 @@ defmodule Feeb.DB.RepoTest do
     end
 
     test "in readonly mode", %{shard_id: shard_id, db: db} do
-      assert {:ok, pid} = start_supervised({Repo, {@context, shard_id, db, :readonly}})
+      assert {:ok, pid} = start_supervised({Repo, {@context, shard_id, db, :readonly, nil}})
 
       state = :sys.get_state(pid)
       c = state.conn

--- a/test/db/repo_test.exs
+++ b/test/db/repo_test.exs
@@ -106,7 +106,7 @@ defmodule Feeb.DB.RepoTest do
       assert {:error, :already_in_transaction} ==
                GS.call(repo, {:begin, :exclusive})
 
-      # Proof that we are in a transaction: we can rollback (only once, of colurse)
+      # Proof that we are in a transaction: we can rollback (only once, of course)
       c = :sys.get_state(repo).conn
       assert {:ok, _} = SQLite.raw(c, "ROLLBACK")
       assert {:error, "cannot rollback - no transaction is active"} = SQLite.raw(c, "ROLLBACK")

--- a/test/db/repo_test.exs
+++ b/test/db/repo_test.exs
@@ -9,7 +9,7 @@ defmodule Feeb.DB.RepoTest do
   setup %{shard_id: shard_id, db: db} = flags do
     repo_pid =
       unless Map.get(flags, :skip_init, false) do
-        {:ok, pid} = start_supervised({Repo, {@context, shard_id, db, :readwrite}})
+        {:ok, pid} = start_supervised({Repo, {@context, shard_id, db, :readwrite, nil}})
 
         pid
       else
@@ -74,7 +74,7 @@ defmodule Feeb.DB.RepoTest do
 
       %{message: reason} =
         assert_raise RuntimeError, fn ->
-          Repo.init({@context, 123, db, :readwrite})
+          Repo.init({@context, 123, db, :readwrite, nil})
         end
 
       assert reason =~ "Unable to open database"
@@ -93,6 +93,10 @@ defmodule Feeb.DB.RepoTest do
       # No longer in a transaction once we commit
       assert :ok == GS.call(repo, {:commit})
       refute :sys.get_state(repo).transaction_id
+
+      # Proof that we are no longer in a transaction: rollback won't work
+      c = :sys.get_state(repo).conn
+      assert {:error, "cannot rollback - no transaction is active"} = SQLite.raw(c, "ROLLBACK")
     end
 
     @tag capture_log: true
@@ -101,6 +105,11 @@ defmodule Feeb.DB.RepoTest do
 
       assert {:error, :already_in_transaction} ==
                GS.call(repo, {:begin, :exclusive})
+
+      # Proof that we are in a transaction: we can rollback (only once, of colurse)
+      c = :sys.get_state(repo).conn
+      assert {:ok, _} = SQLite.raw(c, "ROLLBACK")
+      assert {:error, "cannot rollback - no transaction is active"} = SQLite.raw(c, "ROLLBACK")
     end
 
     @tag capture_log: true
@@ -189,6 +198,59 @@ defmodule Feeb.DB.RepoTest do
       # We can close it
       assert :ok == GS.call(repo, {:close})
       refute Process.alive?(repo)
+    end
+  end
+
+  describe "handle_call: mgt_connection_released" do
+    test "performs a no-op on the regular lifecycle", %{repo: repo} do
+      # This Repo had a regular lifecycle: it started a transaction
+      assert :ok == GS.call(repo, {:begin, :exclusive})
+      assert :sys.get_state(repo).transaction_id
+
+      # And then it committed, which resets the transaction_id
+      assert :ok == GS.call(repo, {:commit})
+      state_after_commit = :sys.get_state(repo)
+      refute state_after_commit.transaction_id
+
+      assert :ok == GS.call(repo, {:mgt_connection_released})
+      state_after_release = :sys.get_state(repo)
+
+      # Nothing changes when the connection is released
+      assert state_after_release == state_after_commit
+    end
+
+    test "rolls back transaction if one exists", %{repo: repo} do
+      # We are in a transaction
+      assert :ok == GS.call(repo, {:begin, :exclusive})
+      assert :sys.get_state(repo).transaction_id
+
+      # Let's assume mgt_connection_released was called with an active transaction -- that means the
+      # caller was forced to end its connection (e.g. due to timeout or caller dying)
+      assert :ok == GS.call(repo, {:mgt_connection_released})
+      refute :sys.get_state(repo).transaction_id
+
+      # If we try to ROLLBACK, SQLite yells at us saying there's no open transaction
+      c = :sys.get_state(repo).conn
+      assert {:error, "cannot rollback - no transaction is active"} = SQLite.raw(c, "ROLLBACK")
+    end
+
+    @tag capture_log: true
+    test "only the repo manager can send the release signal", %{shard_id: shard_id, db: db} do
+      assert {:ok, repo} = Repo.start_link({@context, shard_id, db, :readwrite, self()})
+
+      # It works if called from the same process (here, test process == manager process)
+      assert :ok == GS.call(repo, {:mgt_connection_released})
+
+      # It blows up if called from elsewhere
+      spawn(fn ->
+        GS.call(repo, {:mgt_connection_released})
+        block_forever()
+      end)
+
+      # The Repo died abruptly because someone other than the Manager tried to release it
+      Process.flag(:trap_exit, true)
+      assert_receive {:EXIT, ^repo, {%RuntimeError{message: error}, _stacktrace}}, 100
+      assert error =~ "Repo can only be released by its Manager"
     end
   end
 end

--- a/test/db/schema_test.exs
+++ b/test/db/schema_test.exs
@@ -110,7 +110,7 @@ defmodule DB.SchemaTest do
       assert monica.divorce_count == 0
 
       expected_repo_config =
-        %{
+        %DB.Repo.RepoConfig{
           context: @context,
           shard_id: shard_id,
           mode: :readonly,

--- a/test/support/db.ex
+++ b/test/support/db.ex
@@ -27,7 +27,7 @@ defmodule Test.Feeb.DB do
     path = Repo.get_path(context, shard_id)
 
     # The repo will automatically set up and migrate (if needed)
-    {:ok, pid} = Repo.start_link({context, shard_id, path, :readwrite})
+    {:ok, pid} = Repo.start_link({context, shard_id, path, :readwrite, nil})
 
     # We need to close it in order to synchronously finish the migration
     GenServer.call(pid, {:close})

--- a/test/support/db/prop.ex
+++ b/test/support/db/prop.ex
@@ -1,5 +1,6 @@
 defmodule Test.Feeb.DB.Prop do
   alias Feeb.DB.{SQLite}
+  alias Feeb.DB
   alias __MODULE__
 
   def create(context) do
@@ -21,11 +22,11 @@ defmodule Test.Feeb.DB.Prop do
     File.rm(prop_path)
 
     # Create them (in data dir)
-    Feeb.DB.begin(ctx_name, -99, :write)
-    Feeb.DB.commit()
+    DB.begin(ctx_name, -99, :write)
+    DB.commit()
 
     # Make sure the DB in datadir is synced
-    db_path = Feeb.DB.Repo.get_path(ctx_name, -99)
+    db_path = DB.Repo.get_path(ctx_name, -99)
     {:ok, db_conn} = SQLite.open(db_path)
     :ok = SQLite.exec(db_conn, "PRAGMA wal_checkpoint(TRUNCATE)")
     SQLite.close(db_conn)

--- a/test/support/db/schemas/friend.ex
+++ b/test/support/db/schemas/friend.ex
@@ -1,5 +1,6 @@
 defmodule Sample.Friend do
   use Feeb.DB.Schema
+  alias Feeb.DB
   alias Feeb.DB.Schema
 
   @context :test
@@ -18,7 +19,7 @@ defmodule Sample.Friend do
     |> Schema.create()
   end
 
-  def get_repo_config(_row, repo_config),
+  def get_repo_config(_row, %DB.Repo.RepoConfig{} = repo_config),
     do: repo_config
 
   def get_divorce_count(%{name: name}, _) do

--- a/test/support/utils.ex
+++ b/test/support/utils.ex
@@ -23,4 +23,14 @@ defmodule Test.Utils do
 
     spawn_pid
   end
+
+  @doc """
+  Starts a receive block that will hang indefinitely. This is used for spawned processes that should
+  remain alive until the end of the test suite to avoid flakes.
+  """
+  def block_forever do
+    receive do
+      :will_never_receive -> :ok
+    end
+  end
 end


### PR DESCRIPTION
Any process can fetch a connection. When they do, this connection is locked to this process, which is expected to release it once he's done. What happens if the process dies in the meantime? If it crashes? If it forgets to release?

That's where this PR comes in. If a process terminates without releasing the connection, we'll get notified and we'll clean up their mess.

If the caller process terminated normally (without an exception) and yet the connection was not released, emit a warning: it is likely the application forgot to commit or rollback their transaction.

Finally, in another commit I should handle the scenario where a caller process goes on to live forever with a locked connection. That might be okay, but only if explicitly requested by the caller process. I'm thinking timeout intervals with lease renewals.

EDIT: The above is now handled, except for "lease renewals". That's not needed now and it may never be needed. AFAIK not even Ecto has a similar feature. If the caller needs a big timeout, just set it from the start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a timeout mechanism for connection requests to enhance connection management.
	- Added a new function to notify the repository upon release, improving transaction handling.
	- Introduced a new module for managing repository configuration, including a struct for required fields.

- **Bug Fixes**
	- Enhanced error handling for connection management and transaction rollbacks.

- **Tests**
	- Expanded tests for connection management to cover new timeout scenarios and state validations after connection releases.
	- Updated assertions in existing tests to validate additional connection state fields.
	- Introduced a new function to block processes indefinitely for more reliable testing.
  
- **Documentation**
	- Added documentation for the new `block_forever` function to clarify its purpose in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->