### PR TITLE
Add support for `after_read` callbacks

### DIFF
--- a/priv/test/migrations/test/241020150201_friends.sql
+++ b/priv/test/migrations/test/241020150201_friends.sql
@@ -1,4 +1,5 @@
 CREATE TABLE friends (
   id INTEGER PRIMARY KEY,
-  name TEXT
+  name TEXT,
+  sibling_count INTEGER
 ) STRICT, WITHOUT ROWID;

--- a/test/db/schema_test.exs
+++ b/test/db/schema_test.exs
@@ -29,7 +29,7 @@ defmodule DB.SchemaTest do
 
   describe "generated: __cols__/0" do
     test "includes all non-virtual fields in order" do
-      assert [:id, :name] == Friend.__cols__()
+      assert [:id, :name, :sibling_count] == Friend.__cols__()
 
       assert [
                :boolean,
@@ -121,6 +121,20 @@ defmodule DB.SchemaTest do
       assert phoebe.repo_config == expected_repo_config
       assert rachel.repo_config == expected_repo_config
       assert monica.repo_config == expected_repo_config
+    end
+  end
+
+  describe "after_read" do
+    test "columns with after_read are post-processed", %{shard_id: shard_id} do
+      DB.begin(@context, shard_id, :read)
+
+      joey = DB.one({:friends, :get_by_name}, "Joey")
+      rachel = DB.one({:friends, :get_by_name}, "Rachel")
+      pheebs = DB.one({:friends, :get_by_name}, "Phoebe")
+
+      assert joey.sibling_count == 7
+      assert rachel.sibling_count == 2
+      assert pheebs.sibling_count == 1
     end
   end
 end

--- a/test/db/sqlite_test.exs
+++ b/test/db/sqlite_test.exs
@@ -36,7 +36,7 @@ defmodule Feeb.DB.SQLiteTest do
     test "returns an entry if found", %{c: c} do
       {:ok, stmt} = SQLite.prepare(c, "SELECT * FROM friends WHERE id = ?")
       :ok = SQLite.bind(c, stmt, [1])
-      assert {:ok, [1, "Phoebe"]} == SQLite.one(c, stmt)
+      assert {:ok, [1, "Phoebe", nil]} == SQLite.one(c, stmt)
     end
 
     test "returns nil if not found", %{c: c} do

--- a/test/support/db/schemas/friend.ex
+++ b/test/support/db/schemas/friend.ex
@@ -10,6 +10,7 @@ defmodule Sample.Friend do
     {:id, :integer},
     {:name, :string},
     {:divorce_count, {:integer, virtual: :get_divorce_count}},
+    {:sibling_count, {:integer, nullable: true, after_read: :get_sibling_count}},
     {:repo_config, {:map, virtual: :get_repo_config}}
   ]
 
@@ -36,6 +37,19 @@ defmodule Sample.Friend do
 
       _ ->
         0
+    end
+  end
+
+  def get_sibling_count(_, %{name: name}) do
+    case name do
+      "Joey" ->
+        7
+
+      "Rachel" ->
+        2
+
+      _ ->
+        1
     end
   end
 end


### PR DESCRIPTION
These callbacks are executed after every other field in the schema has been loaded. It receives two arguments: the loaded field as well as the entire loaded schema.

Receiving the entire schema is particularly helpful if the callback needs to have access to some other data from the row in order to execute its logic.

Note that if multiple fields implement the `after_read` callback, there's no guarantee of order over which gets executed first, so one should make sure that in this scenario the order is not strictly necessary and/or can be coordinated via some external medium (e.g. process dictionary).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `sibling_count` field in the `Friend` schema, which dynamically calculates sibling counts based on names.
	- Added functionality for processing fields with `after_read` callbacks in the database schema.
  
- **Bug Fixes**
	- Updated test assertions to reflect changes in the database retrieval logic, ensuring accurate validation of results.

- **Tests**
	- Enhanced test coverage for the `Friend` schema, including new assertions for the `sibling_count` field and after-read processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->