### PR TITLE
Add support for structs in Map type

### DIFF
--- a/lib/feeb/db/type/map.ex
+++ b/lib/feeb/db/type/map.ex
@@ -7,7 +7,7 @@ defmodule Feeb.DB.Type.Map do
   def sqlite_type, do: :text
 
   @doc """
-  When casting, we need to guaranteed that the output follows the `keys` specified in the column
+  When casting, we need to guarantee that the output follows the `keys` specified in the column
   opts. For example, if a field has `keys: :atom` and receives %{"foo" => :bar} as value, we need to
   cast it to %{foo: :bar}.
   """
@@ -30,6 +30,7 @@ defmodule Feeb.DB.Type.Map do
       opts[:keys] == :safe_atom -> v |> JSON.decode!() |> Utils.Map.safe_atomify_keys()
       true -> JSON.decode!(v)
     end
+    |> load_structs(opts)
   end
 
   def load!(nil, %{nullable: true}, _), do: nil
@@ -38,4 +39,7 @@ defmodule Feeb.DB.Type.Map do
     Logger.warning("Loaded `nil` value from non-nullable field: #{field}@#{schema}")
     nil
   end
+
+  defp load_structs(map, %{load_structs: false}), do: map
+  defp load_structs(map, _), do: Utils.Map.load_structs(map)
 end

--- a/lib/feeb/db/type/map.ex
+++ b/lib/feeb/db/type/map.ex
@@ -10,6 +10,11 @@ defmodule Feeb.DB.Type.Map do
   When casting, we need to guarantee that the output follows the `keys` specified in the column
   opts. For example, if a field has `keys: :atom` and receives %{"foo" => :bar} as value, we need to
   cast it to %{foo: :bar}.
+
+  We *must* convert every key based on the `:keys` information set in `opts`; we cannot keep the
+  input as-is. Imagine someone passes an hybrid `%{a: :map, "with" => "strings"}` map with both
+  atoms and strings as keys. It's impossible to know which keys were atom and which ones were string
+  when we `load!/3` the data from disk, since this information is lost during `dump!/3`.
   """
   def cast!(v, opts, _) when is_map(v) do
     cond do

--- a/test/db/db_test.exs
+++ b/test/db/db_test.exs
@@ -508,7 +508,7 @@ defmodule Feeb.DBTest do
                DB.all({:all_types, :get_map}, [], format: :raw) |> Enum.sort()
 
       # With the :type flag, we return the values formatted by their types _without_ the full schema
-      assert [%{map: %{"girl" => ["so", "confusing"]}}, %{map: %{"foo" => "bar"}}] |> Enum.sort() ==
+      assert [%{map: %{girl: ["so", "confusing"]}}, %{map: %{foo: "bar"}}] |> Enum.sort() ==
                DB.all({:all_types, :get_map}, [], format: :type) |> Enum.sort()
 
       assert [%{atom: :i_am_atom, integer: 50}, %{atom: :other_atom, integer: -2}] |> Enum.sort() ==

--- a/test/db/type/map_test.exs
+++ b/test/db/type/map_test.exs
@@ -7,49 +7,86 @@ defmodule Feeb.DB.Type.MapTest do
 
   describe "map type" do
     test "stores and loads correctly", %{shard_id: shard_id} do
-      params = AllTypes.creation_params(%{map: %{"foo" => "bar"}, map_nullable: %{1 => nil}})
+      params =
+        AllTypes.creation_params(%{
+          map: %{foo: "bar"},
+          map_keys_string: %{foo: "bar"},
+          map_nullable: %{1 => nil}
+        })
 
       # Maps are correctly casted
       all_types = AllTypes.new(params)
-      assert all_types.map == %{"foo" => "bar"}
-      assert all_types.map_nullable == %{"1" => nil}
+      assert all_types.map == %{foo: "bar"}
+      assert all_types.map_keys_string == %{"foo" => "bar"}
+      assert all_types.map_nullable == %{1 => nil}
 
       # Maps are correctly dumped and loaded
       DB.begin(@context, shard_id, :write)
       assert {:ok, db_all_types} = DB.insert(all_types)
-      assert db_all_types.map == %{"foo" => "bar"}
-      assert db_all_types.map_nullable == %{"1" => nil}
+      assert db_all_types.map == %{foo: "bar"}
+      assert db_all_types.map_keys_string == %{"foo" => "bar"}
+      assert db_all_types.map_nullable == %{"1": nil}
 
       # Values are stored as text in the database
       assert [["{\"foo\":\"bar\"}", "{\"1\":null}"]] ==
                DB.raw!("select map, map_nullable from all_types")
     end
 
-    test "stores and loads structs inside maps", %{shard_id: shard_id} do
+    test "stores and loads structs (inside maps)", %{shard_id: shard_id} do
       version = %Version{major: 4, minor: 2, patch: 0}
       uri = URI.new!("foo")
 
       map = %{uri: uri, version: version}
       stringified_map = Utils.Map.stringify_keys(map)
 
-      params = AllTypes.creation_params(%{map: map, map_keys_atom: map})
+      params = AllTypes.creation_params(%{map: map, map_keys_string: map})
 
       # Structs are parsed correctly
       all_types = AllTypes.new(params)
-      assert all_types.map == stringified_map
-      assert all_types.map_keys_atom == map
+      assert all_types.map == map
+      assert all_types.map_keys_string == stringified_map
 
       DB.begin(@context, shard_id, :write)
       assert {:ok, db_all_types} = DB.insert(all_types)
-      assert db_all_types.map == stringified_map
-      assert db_all_types.map_keys_atom == map
+      assert db_all_types.map == map
+      assert db_all_types.map_keys_string == stringified_map
 
-      # Structs are stored next to the map, under the __struct__ key
-      assert [[raw_map, raw_map_keys_atom]] = DB.raw!("select map, map_keys_atom from all_types")
-      assert raw_map_keys_atom =~ "\"__struct__\":\"Elixir.URI\""
+      # Structs are stored next to the map, under the __struct__ key, except in the stringified map
+      assert [[raw_map, raw_map_keys_string]] =
+               DB.raw!("select map, map_keys_string from all_types")
 
-      # Except in the stringified (non-atom) map
-      refute raw_map =~ "\"__struct__\":\"Elixir.URI\""
+      assert raw_map =~ "\"__struct__\":\"Elixir.URI\""
+      refute raw_map_keys_string =~ "\"__struct__\":\"Elixir.URI\""
+    end
+
+    test "stores and loads struct (at the top level)", %{shard_id: shard_id} do
+      version = %Version{major: 4, minor: 2, patch: 0, build: nil, pre: []}
+
+      params =
+        AllTypes.creation_params(%{
+          map: version,
+          map_keys_string: version,
+          map_keys_safe_atom: version
+        })
+
+      stringified_map =
+        version
+        |> Map.from_struct()
+        |> Utils.Map.stringify_keys()
+
+      # Structs are parsed correctly. Note that for map with `keys: :string`, the struct is removed
+      # entirely and instead we end up with the raw map with stringified keys
+      all_types = AllTypes.new(params)
+      assert all_types.map == version
+      assert all_types.map_keys_safe_atom == version
+      assert all_types.map_keys_string == stringified_map
+
+      # We can store/load the struct in the database (when keys is atom or safe_atom)
+      DB.begin(@context, shard_id, :write)
+      assert {:ok, db_all_types} = DB.insert(all_types)
+      assert db_all_types.map == version
+      assert db_all_types.map_keys_safe_atom == version
+      assert db_all_types.map_keys_string == stringified_map
     end
 
     test "supports nullable", %{shard_id: shard_id} do
@@ -83,7 +120,7 @@ defmodule Feeb.DB.Type.MapTest do
       assert all_types.map_keys_atom == input
       assert all_types.map_keys_safe_atom == input
       assert all_types.map_keys_string == input_str
-      assert all_types.map_keys_default == input_str
+      assert all_types.map_keys_default == input
 
       DB.begin(@context, shard_id, :write)
       assert {:ok, db_all_types} = DB.insert(all_types)
@@ -92,7 +129,7 @@ defmodule Feeb.DB.Type.MapTest do
       assert db_all_types.map_keys_atom == input
       assert db_all_types.map_keys_safe_atom == input
       assert db_all_types.map_keys_string == input_str
-      assert db_all_types.map_keys_default == input_str
+      assert db_all_types.map_keys_default == input
 
       # In the database, these fields are stored as text with the exact same value
       expected_value = "{\"foo\":{\"bar\":\"baz\"}}"
@@ -141,6 +178,17 @@ defmodule Feeb.DB.Type.MapTest do
       assert log =~ "[warning]"
       assert log =~ "Loaded `nil` value"
       assert log =~ "map@"
+    end
+  end
+
+  describe "overwrite_opts/3" do
+    test "keeps `:keys` if one is given" do
+      opts = %{keys: :atom}
+      assert opts == DB.Type.Map.overwrite_opts(opts, nil, nil)
+    end
+
+    test "adds default `:keys` if none is given" do
+      assert %{keys: :atom} == DB.Type.Map.overwrite_opts(%{}, nil, nil)
     end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of map key types with options for `:keys`.
	- Introduced functionality for loading and converting structs within maps.
	- Added support for different key types: `:string`, `:atom`, and `:safe_atom`.

- **Bug Fixes**
	- Updated tests to reflect changes in expected output format, ensuring keys are now atoms instead of strings.

- **Tests**
	- Added new tests for storing and retrieving structs in maps.
	- Expanded test coverage for the `overwrite_opts/3` function to verify key option handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->