### PR TITLE
Improve structs support in Map type

### DIFF
--- a/lib/feeb/db/type/map.ex
+++ b/lib/feeb/db/type/map.ex
@@ -53,6 +53,6 @@ defmodule Feeb.DB.Type.Map do
     nil
   end
 
-  defp load_structs(map, %{load_structs: false}), do: map
-  defp load_structs(map, _), do: Utils.Map.load_structs(map)
+  defp load_structs(map, %{load_structs: true}), do: Utils.Map.load_structs(map)
+  defp load_structs(map, _), do: map
 end

--- a/lib/feeb/db/utils/map.ex
+++ b/lib/feeb/db/utils/map.ex
@@ -58,6 +58,9 @@ defmodule Utils.Map do
 
   def load_structs(map) when is_map(map) do
     Enum.reduce(map, %{}, fn
+      {k, v}, acc when is_struct(v) ->
+        Map.put(acc, k, v)
+
       {k, v}, acc when is_map(v) ->
         new_v =
           if Map.has_key?(v, :__struct__) or Map.has_key?(v, "__struct__") do
@@ -88,6 +91,8 @@ defmodule Utils.Map do
   defp convert_to_struct(raw_struct_mod, entries) when is_binary(raw_struct_mod),
     do: convert_to_struct(String.to_existing_atom(raw_struct_mod), safe_atomify_keys(entries))
 
-  defp convert_to_struct(struct_mod, entries) when is_atom(struct_mod),
-    do: struct(struct_mod, entries)
+  defp convert_to_struct(struct_mod, entries) when is_atom(struct_mod) do
+    entries = Map.drop(entries, [:__struct__, "__struct__"])
+    struct(struct_mod, load_structs(entries))
+  end
 end

--- a/lib/feeb/db/utils/map.ex
+++ b/lib/feeb/db/utils/map.ex
@@ -58,41 +58,17 @@ defmodule Utils.Map do
 
   def load_structs(map) when is_map(map) do
     Enum.reduce(map, %{}, fn
-      {k, v}, acc when is_struct(v) ->
-        Map.put(acc, k, v)
-
-      {k, v}, acc when is_map(v) ->
-        new_v =
-          if Map.has_key?(v, :__struct__) or Map.has_key?(v, "__struct__") do
-            convert_to_struct(v[:__struct__] || v["__struct__"], v)
+      {k, v}, acc ->
+        {new_k, new_v} =
+          if k == :__struct__ or k == "__struct__" do
+            {:__struct__, String.to_existing_atom(v)}
           else
-            load_structs(v)
+            {k, load_structs(v)}
           end
 
-        Map.put(acc, k, new_v)
-
-      {k, v}, acc ->
-        Map.put(acc, k, load_structs(v))
+        Map.put(acc, new_k, new_v)
     end)
-    |> maybe_convert_top_level_struct()
   end
 
   def load_structs(v), do: v
-
-  defp maybe_convert_top_level_struct(%{__struct__: struct_mod} = entries),
-    do: convert_to_struct(struct_mod, entries)
-
-  defp maybe_convert_top_level_struct(%{"__struct__" => struct_mod} = entries),
-    do: convert_to_struct(struct_mod, entries)
-
-  defp maybe_convert_top_level_struct(map),
-    do: map
-
-  defp convert_to_struct(raw_struct_mod, entries) when is_binary(raw_struct_mod),
-    do: convert_to_struct(String.to_existing_atom(raw_struct_mod), safe_atomify_keys(entries))
-
-  defp convert_to_struct(struct_mod, entries) when is_atom(struct_mod) do
-    entries = Map.drop(entries, [:__struct__, "__struct__"])
-    struct(struct_mod, load_structs(entries))
-  end
 end

--- a/priv/test/migrations/test/241020150400_all_types.sql
+++ b/priv/test/migrations/test/241020150400_all_types.sql
@@ -20,6 +20,7 @@ CREATE TABLE all_types (
   datetime_utc_precision_microsecond TEXT,
   datetime_utc_precision_default TEXT,
   map TEXT,
+  map_load_structs TEXT,
   map_nullable TEXT,
   map_keys_atom TEXT,
   map_keys_safe_atom TEXT,

--- a/test/db/schema_test.exs
+++ b/test/db/schema_test.exs
@@ -49,6 +49,7 @@ defmodule DB.SchemaTest do
                :datetime_utc_precision_microsecond,
                :datetime_utc_precision_default,
                :map,
+               :map_load_structs,
                :map_nullable,
                :map_keys_atom,
                :map_keys_safe_atom,

--- a/test/support/db/schemas/all_types.ex
+++ b/test/support/db/schemas/all_types.ex
@@ -23,6 +23,7 @@ defmodule Sample.AllTypes do
     {:datetime_utc_precision_microsecond, {:datetime_utc, precision: :microsecond, nullable: true}},
     {:datetime_utc_precision_default, {:datetime_utc, nullable: true}},
     {:map, :map},
+    {:map_load_structs, {:map, load_structs: true, nullable: true}},
     {:map_nullable, {:map, nullable: true}},
     {:map_keys_atom, {:map, keys: :atom, nullable: true}},
     {:map_keys_safe_atom, {:map, keys: :safe_atom, nullable: true}},


### PR DESCRIPTION
Changes include:

- Support nested structs.
- Change `:map` type to *not* load structs by default, since it may impact performance negatively.
- Vastly simplified implementation of the `load_structs/1` util.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new `map_load_structs` field to support advanced map and struct handling
	- Enhanced map loading functionality with more flexible struct processing

- **Bug Fixes**
	- Improved struct loading logic to provide more precise control over map transformations

- **Tests**
	- Added new test cases to verify struct loading behavior in various scenarios
	- Updated existing tests to validate new map handling capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->