### PR TITLE
Simplify virtual fields

### DIFF
--- a/test/support/db/schemas/all_types.ex
+++ b/test/support/db/schemas/all_types.ex
@@ -33,7 +33,9 @@ defmodule Sample.AllTypes do
     {:list_nullable, {:list, nullable: true}},
     {:enum, {:enum, values: [:one, :two, :three]}},
     {:enum_nullable, {:enum, values: ["foo", "bar", "baz"], nullable: true}},
-    {:enum_safe_atom, {:enum, values: [:safe, :atom], format: :safe_atom, nullable: true}}
+    {:enum_safe_atom, {:enum, values: [:safe, :atom], format: :safe_atom, nullable: true}},
+    {:virtual, {:integer, virtual: true}},
+    {:virtual_with_after_read, {:integer, virtual: true, after_read: :load_virtual_integer}}
   ]
 
   def new(params) do
@@ -56,4 +58,6 @@ defmodule Sample.AllTypes do
     }
     |> Map.merge(overwrites)
   end
+
+  def load_virtual_integer(_field, row, _repo_config), do: row.integer
 end

--- a/test/support/db/schemas/friend.ex
+++ b/test/support/db/schemas/friend.ex
@@ -9,9 +9,9 @@ defmodule Sample.Friend do
   @schema [
     {:id, :integer},
     {:name, :string},
-    {:divorce_count, {:integer, virtual: :get_divorce_count}},
+    {:divorce_count, {:integer, virtual: true, after_read: :get_divorce_count}},
     {:sibling_count, {:integer, nullable: true, after_read: :get_sibling_count}},
-    {:repo_config, {:map, virtual: :get_repo_config}}
+    {:repo_config, {:map, virtual: true, after_read: :get_repo_config}}
   ]
 
   def new(params) do
@@ -20,10 +20,10 @@ defmodule Sample.Friend do
     |> Schema.create()
   end
 
-  def get_repo_config(_row, %DB.Repo.RepoConfig{} = repo_config),
+  def get_repo_config(_field, _row, %DB.Repo.RepoConfig{} = repo_config),
     do: repo_config
 
-  def get_divorce_count(%{name: name}, _) do
+  def get_divorce_count(_, %{name: name}, _) do
     case name do
       "Ross" ->
         3
@@ -40,7 +40,7 @@ defmodule Sample.Friend do
     end
   end
 
-  def get_sibling_count(_, %{name: name}) do
+  def get_sibling_count(_, %{name: name}, _) do
     case name do
       "Joey" ->
         7


### PR DESCRIPTION
Previously, the `:virtual` definition would both 1) define the field as virtual and 2) define which callback (or hard-coded value) it should be set to. I think trying to overload the definition of `:virtual` with multiple purposes was the wrong approach; if one desires a custom value for it they should use either `after_read` or `default` (which is not implemented yet).

Incidental changes:

- Now the `after_read` callback receives a third argument, the `RepoConfig` struct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for virtual fields with more flexible configuration
	- Introduced enhanced after-read callbacks for schema fields
	- Improved handling of repository configuration during field processing

- **Bug Fixes**
	- Simplified virtual field assignment mechanism
	- Refined callback function signatures for better context management

- **Tests**
	- Added comprehensive tests for virtual field behavior
	- Verified default values and insertion handling for virtual fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->