### PR TITLE
Add support for `DB.update_all/3` and `DB.delete_all/3`

### DIFF
--- a/lib/feeb/db.ex
+++ b/lib/feeb/db.ex
@@ -256,6 +256,21 @@ defmodule Feeb.DB do
     r
   end
 
+  def delete_all(partial_or_full_query_id, bindings, opts \\ [])
+
+  def delete_all({domain, query_name}, bindings, opts) do
+    delete_all({get_context!(), domain, query_name}, bindings, opts)
+  end
+
+  def delete_all({_, domain, query_name}, bindings, opts) do
+    GenServer.call(get_pid!(), {:query, :delete_all, {domain, query_name}, bindings, opts})
+  end
+
+  def delete_all!(query_id, params, opts \\ []) do
+    {:ok, r} = delete_all(query_id, params, opts)
+    r
+  end
+
   ##################################################################################################
   # Private
   ##################################################################################################

--- a/lib/feeb/db.ex
+++ b/lib/feeb/db.ex
@@ -145,19 +145,18 @@ defmodule Feeb.DB do
     end
   end
 
-  def insert(%schema{} = struct) do
+  def insert(%schema{} = struct, opts \\ []) do
     {get_context!(), schema.__table__(), :__insert}
     |> Query.get_templated_query_id(:all, %{schema: schema})
-    |> insert(struct, [])
+    |> insert_sql(struct, opts)
   end
 
-  def insert(partial_or_full_query_id, struct, opts \\ [])
-
-  def insert({domain, query_name}, %_{} = struct, opts) do
-    insert({get_context!(), domain, query_name}, struct, opts)
+  def insert!(struct) do
+    {:ok, r} = insert(struct)
+    r
   end
 
-  def insert({_, domain, query_name} = full_query_id, %_{} = struct, opts) do
+  defp insert_sql({_, domain, query_name} = full_query_id, %_{} = struct, opts) do
     # TODO: Make it more friendly
     true = :application == struct.__meta__.origin
 
@@ -169,35 +168,10 @@ defmodule Feeb.DB do
     end
   end
 
-  def insert!(struct) do
-    {:ok, r} = insert(struct)
-    r
-  end
-
-  def insert!(query, struct, opts \\ []) do
-    {:ok, r} = insert(query, struct, opts)
-    r
-  end
-
-  # TODO Test
-  def update(%schema{} = struct) do
+  def update(%schema{} = struct, opts \\ []) do
     {get_context!(), schema.__table__(), :__update}
     |> Query.get_templated_query_id(struct.__meta__.target, %{})
-    |> update(struct, [])
-  end
-
-  def update(partial_or_full_query_id, struct, opts \\ [])
-
-  def update({domain, query_name}, %_{} = struct, opts) do
-    update({get_context!(), domain, query_name}, struct, opts)
-  end
-
-  def update({_, domain, query_name} = full_query_id, %_{} = struct, opts) do
-    # TODO: Make it more friendly
-    true = :db == struct.__meta__.origin
-
-    bindings = get_bindings(full_query_id, struct)
-    GenServer.call(get_pid!(), {:query, :update, {domain, query_name}, bindings, opts})
+    |> update_sql(struct, Keyword.merge(opts, returning: true))
   end
 
   def update!(struct) do
@@ -205,9 +179,12 @@ defmodule Feeb.DB do
     r
   end
 
-  def update!(query_id, struct, opts \\ []) do
-    {:ok, r} = update(query_id, struct, opts)
-    r
+  defp update_sql({_, domain, query_name} = full_query_id, %_{} = struct, opts) do
+    # TODO: Make it more friendly
+    true = :db == struct.__meta__.origin
+
+    bindings = get_bindings(full_query_id, struct)
+    GenServer.call(get_pid!(), {:query, :update, {domain, query_name}, bindings, opts})
   end
 
   def update_all(partial_or_full_query_id, bindings, opts \\ [])
@@ -225,25 +202,10 @@ defmodule Feeb.DB do
     r
   end
 
-  # TODO: Test
-  def delete(%schema{} = struct) do
+  def delete(%schema{} = struct, opts \\ []) do
     {get_context!(), schema.__table__(), :__delete}
     |> Query.get_templated_query_id([], %{})
-    |> update(struct, [])
-  end
-
-  def delete(partial_or_full_query_id, struct, opts \\ [])
-
-  def delete({domain, query_name}, %_{} = struct, opts) do
-    delete({get_context!(), domain, query_name}, struct, opts)
-  end
-
-  def delete({_, domain, query_name} = full_query_id, %_{} = struct, opts) do
-    # TODO: Make it more friendly
-    true = :db == struct.__meta__.origin
-
-    bindings = get_bindings(full_query_id, struct)
-    GenServer.call(get_pid!(), {:query, :delete, {domain, query_name}, bindings, opts})
+    |> delete_sql(struct, Keyword.merge([returning: true], opts))
   end
 
   def delete!(struct) do
@@ -251,9 +213,12 @@ defmodule Feeb.DB do
     r
   end
 
-  def delete!(query_id, struct, opts \\ []) do
-    {:ok, r} = delete(query_id, struct, opts)
-    r
+  defp delete_sql({_, domain, query_name} = full_query_id, %_{} = struct, opts) do
+    # TODO: Make it more friendly
+    true = :db == struct.__meta__.origin
+
+    bindings = get_bindings(full_query_id, struct)
+    GenServer.call(get_pid!(), {:query, :delete, {domain, query_name}, bindings, opts})
   end
 
   def delete_all(partial_or_full_query_id, bindings, opts \\ [])

--- a/lib/feeb/db.ex
+++ b/lib/feeb/db.ex
@@ -210,6 +210,21 @@ defmodule Feeb.DB do
     r
   end
 
+  def update_all(partial_or_full_query_id, bindings, opts \\ [])
+
+  def update_all({domain, query_name}, bindings, opts) do
+    update_all({get_context!(), domain, query_name}, bindings, opts)
+  end
+
+  def update_all({_, domain, query_name}, bindings, opts) do
+    GenServer.call(get_pid!(), {:query, :update_all, {domain, query_name}, bindings, opts})
+  end
+
+  def update_all!(query_id, params, opts \\ []) do
+    {:ok, r} = update_all(query_id, params, opts)
+    r
+  end
+
   # TODO: Test
   def delete(%schema{} = struct) do
     {get_context!(), schema.__table__(), :__delete}

--- a/lib/feeb/db/repo.ex
+++ b/lib/feeb/db/repo.ex
@@ -326,6 +326,11 @@ defmodule Feeb.DB.Repo do
 
   defp format_result(:delete, _, _, [], _bindings, _), do: {:ok, []}
 
+  defp format_result(:delete_all, _, _, [], _, _) do
+    # PS: If RETURNING, I need to differentiate between [] (no rows updated) or [] (no RETURNING)
+    {:ok, nil}
+  end
+
   defp create_schema_from_rows({_, :pragma, _}, _, rows), do: rows
 
   defp create_schema_from_rows(query_id, {_, {fields_bindings, _}, :select}, rows) do

--- a/lib/feeb/db/repo.ex
+++ b/lib/feeb/db/repo.ex
@@ -319,6 +319,11 @@ defmodule Feeb.DB.Repo do
     {:ok, nil}
   end
 
+  defp format_result(:update_all, _, _, [], _, _) do
+    # PS: If RETURNING, I need to differentiate between [] (no rows updated) or [] (no RETURNING)
+    {:ok, nil}
+  end
+
   defp format_result(:delete, _, _, [], _bindings, _), do: {:ok, []}
 
   defp create_schema_from_rows({_, :pragma, _}, _, rows), do: rows

--- a/priv/test/migrations/test/241020150300_blog.sql
+++ b/priv/test/migrations/test/241020150300_blog.sql
@@ -2,6 +2,7 @@
     id INTEGER PRIMARY KEY,
     title TEXT,
     body TEXT,
+    is_draft INTEGER,
     inserted_at TEXT,
     updated_at TEXT
   ) STRICT;

--- a/priv/test/queries/test/posts.sql
+++ b/priv/test/queries/test/posts.sql
@@ -1,0 +1,2 @@
+-- :publish_posts_by_title
+UPDATE posts SET is_draft = 0 WHERE title = ?;

--- a/priv/test/queries/test/posts.sql
+++ b/priv/test/queries/test/posts.sql
@@ -1,2 +1,5 @@
 -- :publish_posts_by_title
 UPDATE posts SET is_draft = 0 WHERE title = ?;
+
+-- :delete_all_drafts
+DELETE FROM posts WHERE is_draft = 1;

--- a/test/db/db_test.exs
+++ b/test/db/db_test.exs
@@ -569,4 +569,37 @@ defmodule Feeb.DBTest do
       assert nil == DB.update_all!({:posts, :publish_posts_by_title}, ["No matches"])
     end
   end
+
+  describe "delete_all/3" do
+    test "performs the SQL-based delete", %{shard_id: shard_id} do
+      DB.begin(@context, shard_id, :write)
+
+      %{id: 1, title: "Post", body: "My Body", is_draft: true}
+      |> Post.new()
+      |> DB.insert!()
+
+      %{id: 2, title: "Post", body: "My Body", is_draft: true}
+      |> Post.new()
+      |> DB.insert!()
+
+      %{id: 3, title: "Not a draft", body: "My Body", is_draft: false}
+      |> Post.new()
+      |> DB.insert!()
+
+      # Initially there are 3 posts
+      assert [_, _, _] = DB.all(Post)
+
+      assert {:ok, nil} == DB.delete_all({:posts, :delete_all_drafts}, [])
+
+      # Now there's only one (the non-draft one)
+      assert [_] = DB.all(Post)
+    end
+  end
+
+  describe "delete_all!/3" do
+    test "performs the SQL-based delete", %{shard_id: shard_id} do
+      DB.begin(@context, shard_id, :write)
+      assert nil == DB.update_all!({:posts, :delete_all_drafts}, [])
+    end
+  end
 end

--- a/test/db/schema_test.exs
+++ b/test/db/schema_test.exs
@@ -84,7 +84,7 @@ defmodule DB.SchemaTest do
       DB.begin(@context, shard_id, :write)
 
       friend = Friend.new(%{id: 7, name: "Mike"})
-      assert {:ok, inserted_friend} = DB.insert({:friends, :insert}, friend)
+      assert {:ok, inserted_friend} = DB.insert(friend)
 
       # The data was inserted correctly
       assert inserted_friend.id == friend.id

--- a/test/support/db/schemas/friend.ex
+++ b/test/support/db/schemas/friend.ex
@@ -20,6 +20,11 @@ defmodule Sample.Friend do
     |> Schema.create()
   end
 
+  def update(%_{} = row, changes) do
+    row
+    |> Schema.update(changes)
+  end
+
   def get_repo_config(_field, _row, %DB.Repo.RepoConfig{} = repo_config),
     do: repo_config
 

--- a/test/support/db/schemas/post.ex
+++ b/test/support/db/schemas/post.ex
@@ -10,8 +10,8 @@ defmodule Sample.Post do
     {:title, :string},
     {:body, :string},
     {:is_draft, {:boolean, nullable: true}},
-    {:inserted_at, {:datetime_utc, [precision: :millisecond], mod: :inserted_at}},
-    {:updated_at, {:datetime_utc, [precision: :millisecond], mod: :updated_at}}
+    {:inserted_at, {:datetime_utc, [], mod: :inserted_at}},
+    {:updated_at, {:datetime_utc, [], mod: :updated_at}}
   ]
 
   def new(params) do

--- a/test/support/db/schemas/post.ex
+++ b/test/support/db/schemas/post.ex
@@ -9,6 +9,7 @@ defmodule Sample.Post do
     {:id, :integer},
     {:title, :string},
     {:body, :string},
+    {:is_draft, {:boolean, nullable: true}},
     {:inserted_at, {:datetime_utc, [precision: :millisecond], mod: :inserted_at}},
     {:updated_at, {:datetime_utc, [precision: :millisecond], mod: :updated_at}}
   ]


### PR DESCRIPTION
`DB.update_all/3` and `DB.delete_all/3` are similar to the corresponding Ecto.Repo counterparts: they allow multiple rows to be updated/deleted from a single query.

Incidentally, this PR also:

1. Adds support for "implicit" `RETURNING` clause.
2. Simplifies the public API of `Feeb.DB`.

The first point above means that regular updates (via `DB.update/2`) will now return the updated row (previously a successful update would return `{:ok, nil}`, which is far from ideal).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for batch update and delete operations, allowing multiple records to be updated or deleted in a single call.
  - Introduced new options for returning updated or deleted records directly from update and delete operations.
  - Added new SQL queries for publishing posts by title and deleting all draft posts.

- **Improvements**
  - Simplified the interface for insert, update, and delete operations, making them easier to use with optional parameters.
  - Enhanced schema definitions and migrations, including a new nullable draft status field for posts.
  - Unified and extended result formatting to support returning options for update and delete queries.

- **Bug Fixes**
  - Improved handling and formatting of results for update and delete operations, especially when using returning options.

- **Tests**
  - Expanded test coverage for CRUD and batch operations, including error handling and result verification.
  - Simplified test calls by removing explicit query tuples in favor of struct-based operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->