### PR TITLE
Add support for `DB.reload/1` and `DB.reload!/1`

### DIFF
--- a/lib/feeb/db.ex
+++ b/lib/feeb/db.ex
@@ -236,6 +236,35 @@ defmodule Feeb.DB do
     r
   end
 
+  def reload(%schema{} = struct) do
+    # Support for custom or composite PKs is TODO
+    primary_key_cols = [:id]
+
+    bindings =
+      Enum.map(primary_key_cols, fn col_name ->
+        Map.fetch!(struct, col_name)
+      end)
+
+    one({schema.__table__(), :fetch}, bindings)
+  end
+
+  def reload(schemas) when is_list(schemas),
+    do: Enum.map(schemas, &reload/1)
+
+  def reload!(%schema{} = struct) do
+    case reload(struct) do
+      %^schema{} = result ->
+        result
+
+      nil ->
+        # TODO: Only log the PK of the struct
+        raise "Unable to reload; entry not found: #{inspect(struct)}"
+    end
+  end
+
+  def reload!(schemas) when is_list(schemas),
+    do: Enum.map(schemas, &reload!/1)
+
   ##################################################################################################
   # Private
   ##################################################################################################


### PR DESCRIPTION
Mostly syntactic sugar for users of the library. Makes for easier-to-read tests!

Support for custom or composite PKs is todo. Possibly coming up in the next PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to reload a single record or a list of records from the database, reflecting their latest state.
  - Introduced error-raising variants for reloading that notify when a record cannot be found.

- **Tests**
  - Added comprehensive tests to verify correct behavior, error handling, and order preservation for the new reload features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->