### PR TITLE
Add support for custom selection fields

### DIFF
--- a/lib/feeb/db.ex
+++ b/lib/feeb/db.ex
@@ -107,7 +107,9 @@ defmodule Feeb.DB do
   def one({domain, :fetch}, value, opts), do: one({domain, :fetch}, [value], opts)
 
   def one({domain, query_name}, bindings, opts) when is_list(bindings) do
-    one({get_context!(), domain, query_name}, bindings, opts)
+    {get_context!(), domain, query_name}
+    |> get_query_id_for_select_query(opts)
+    |> one(bindings, opts)
   end
 
   def one({domain, query_name}, value, opts), do: one({domain, query_name}, [value], opts)
@@ -135,13 +137,15 @@ defmodule Feeb.DB do
     |> all([], opts)
   end
 
-  def all({domain, query_name}, bindings, opts) do
-    all({get_context!(), domain, query_name}, bindings, opts)
+  def all({domain, query_name}, bindings, opts) when is_list(bindings) do
+    {get_context!(), domain, query_name}
+    |> get_query_id_for_select_query(opts)
+    |> all(bindings, opts)
   end
 
-  def all({_, domain, query_name}, bindings, opts) do
-    bindings = if is_list(bindings), do: bindings, else: [bindings]
+  def all({domain, query_name}, value, opts), do: all({domain, query_name}, [value], opts)
 
+  def all({_, domain, query_name}, bindings, opts) do
     case GenServer.call(get_pid!(), {:query, :all, {domain, query_name}, bindings, opts}) do
       {:ok, rows} -> rows
       {:error, reason} -> raise reason
@@ -289,6 +293,18 @@ defmodule Feeb.DB do
 
   defp get_context! do
     LocalState.get_current_context!().context
+  end
+
+  defp get_query_id_for_select_query(original_query_id, []), do: original_query_id
+
+  defp get_query_id_for_select_query(original_query_id, opts) do
+    target_fields = opts[:select] || [:*]
+
+    if target_fields == [:*] do
+      original_query_id
+    else
+      Query.compile_adhoc_query(original_query_id, target_fields)
+    end
   end
 
   defp get_bindings(query_id, struct) do

--- a/lib/feeb/db.ex
+++ b/lib/feeb/db.ex
@@ -96,10 +96,11 @@ defmodule Feeb.DB do
 
   def one(partial_or_full_query_id, bindings \\ [], opts \\ [])
 
-  # TODO: See Feeb.DB, I also support `custom_fields`
   def one({domain, :fetch}, bindings, opts) when is_list(bindings) do
+    target_fields = opts[:select] || [:*]
+
     {get_context!(), domain, :__fetch}
-    |> Query.get_templated_query_id([], %{})
+    |> Query.get_templated_query_id(target_fields, %{})
     |> one(bindings, opts)
   end
 
@@ -127,8 +128,10 @@ defmodule Feeb.DB do
   def all(partial_or_full_query_id, bindings \\ [], opts \\ [])
 
   def all(schema, _bindings, opts) when is_atom(schema) do
+    target_fields = opts[:select] || [:*]
+
     {get_context!(), schema.__table__(), :__all}
-    |> Query.get_templated_query_id(:all, %{})
+    |> Query.get_templated_query_id(target_fields, %{})
     |> all([], opts)
   end
 
@@ -147,7 +150,7 @@ defmodule Feeb.DB do
 
   def insert(%schema{} = struct, opts \\ []) do
     {get_context!(), schema.__table__(), :__insert}
-    |> Query.get_templated_query_id(:all, %{schema: schema})
+    |> Query.get_templated_query_id([:*], %{schema: schema})
     |> insert_sql(struct, opts)
   end
 

--- a/lib/feeb/db/repo.ex
+++ b/lib/feeb/db/repo.ex
@@ -283,8 +283,8 @@ defmodule Feeb.DB.Repo do
 
   defp format_result(:one, _, _, [row], _, %{format: :raw}), do: {:ok, row}
 
-  defp format_result(:one, query_id, query, [row], _, %{format: :type}),
-    do: {:ok, create_types_from_rows(query_id, query, [row]) |> List.first()}
+  defp format_result(:one, query_id, query, [row], _, %{format: :map}),
+    do: {:ok, create_maps_from_rows(query_id, query, [row]) |> List.first()}
 
   defp format_result(:one, query_id, query, [row], _, _),
     do: {:ok, create_schema_from_rows(query_id, query, [row]) |> List.first()}
@@ -295,13 +295,13 @@ defmodule Feeb.DB.Repo do
   defp format_result(:all, _, _, [], _, _), do: {:ok, []}
   defp format_result(:all, _, _, rows, _, %{format: :raw}), do: {:ok, rows}
 
-  defp format_result(:all, query_id, query, rows, _, %{format: :type}),
-    do: {:ok, create_types_from_rows(query_id, query, rows)}
+  defp format_result(:all, query_id, query, rows, _, %{format: :map}),
+    do: {:ok, create_maps_from_rows(query_id, query, rows)}
 
   defp format_result(:all, query_id, query, rows, _, %{format: :schema}),
     do: {:ok, create_schema_from_rows(query_id, query, rows)}
 
-  defp format_result(:insert, _, _, [], _, %{format: format}) when format in [:raw, :type],
+  defp format_result(:insert, _, _, [], _, %{format: format}) when format in [:raw, :map],
     do: {:ok, nil}
 
   defp format_result(:insert, query_id, query, [], bindings, %{format: :schema}) do
@@ -364,7 +364,7 @@ defmodule Feeb.DB.Repo do
     Enum.map(rows, fn row -> Schema.from_row(model, model.__cols__(), row) end)
   end
 
-  defp create_types_from_rows(query_id, {_, {fields_bindings, _}, :select} = query, rows) do
+  defp create_maps_from_rows(query_id, {_, {fields_bindings, _}, :select} = query, rows) do
     # Performance-wise, not the best solution, but I'd rather keep the code readable for a bit
     # longer. Simply create the full schema and use only the fields the user selected
     create_schema_from_rows(query_id, query, rows)

--- a/lib/feeb/db/schema.ex
+++ b/lib/feeb/db/schema.ex
@@ -126,7 +126,8 @@ defmodule Feeb.DB.Schema do
     assert_env.(:schema)
   end
 
-  defmacro cast(args, target_fields \\ unquote(:all)) do
+  # TODO: Why is this a macro?
+  defmacro cast(args, target_fields \\ unquote([:*])) do
     quote do
       meta = %{
         valid?: true,

--- a/priv/test/queries/test/all_types.sql
+++ b/priv/test/queries/test/all_types.sql
@@ -7,6 +7,9 @@ select map_keys_atom from all_types;
 -- :get_map
 select map from all_types;
 
+-- :get_by_integer
+select * from all_types where integer = ?;
+
 -- :get_max_integer
 select max(integer) from all_types;
 

--- a/test/db/db_test.exs
+++ b/test/db/db_test.exs
@@ -437,6 +437,13 @@ defmodule Feeb.DBTest do
       assert nil == DB.one({:order_items, :fetch}, [2, 1])
     end
 
+    test "supports custom selection on user-defined queries", %{shard_id: shard_id} do
+      DB.begin(@context, shard_id, :read)
+
+      assert %{id: %NotLoaded{}, name: "Phoebe"} =
+               DB.one({:friends, :get_by_name}, "Phoebe", select: [:name])
+    end
+
     test "supports the :format flag", %{shard_id: shard_id} do
       DB.begin(@context, shard_id, :write)
 
@@ -534,6 +541,13 @@ defmodule Feeb.DBTest do
       |> DB.insert!()
 
       assert [%{id: 1, title: "Post", body: %NotLoaded{}}] = DB.all(Post, [], select: [:id, :title])
+    end
+
+    test "supports custom selection on user-defined queries", %{shard_id: shard_id} do
+      DB.begin(@context, shard_id, :read)
+
+      assert [%{id: %NotLoaded{}, name: "Phoebe"}] =
+               DB.all({:friends, :get_by_name}, "Phoebe", select: [:name])
     end
 
     test "supports the :format flag", %{shard_id: shard_id} do

--- a/test/db/db_test.exs
+++ b/test/db/db_test.exs
@@ -468,6 +468,14 @@ defmodule Feeb.DBTest do
 
       assert %{atom: :i_am_atom, integer: 50} ==
                DB.one({:all_types, :get_atom_and_integer}, [], format: :type)
+
+      # Custom selection with different formats
+      assert ["Phoebe"] = DB.one({:friends, :fetch}, [1], select: [:name], format: :raw)
+      assert %{name: "Phoebe"} = DB.one({:friends, :fetch}, [1], select: [:name], format: :type)
+
+      # No matching results
+      assert nil == DB.one({:friends, :fetch}, [500], select: [:name], format: :raw)
+      assert nil == DB.one({:friends, :fetch}, [500], select: [:name], format: :type)
     end
 
     test "works with window functions when using :raw flag", %{shard_id: shard_id} do
@@ -581,6 +589,15 @@ defmodule Feeb.DBTest do
 
       assert [%{atom: :i_am_atom, integer: 50}, %{atom: :other_atom, integer: -2}] |> Enum.sort() ==
                DB.all({:all_types, :get_atom_and_integer}, [], format: :type) |> Enum.sort()
+
+      # Custom selection with different formats
+      assert [%{name: "Phoebe"}] =
+               DB.all({:friends, :get_by_name}, "Phoebe", select: [:name], format: :type)
+
+      assert [["Joey"]] = DB.all({:friends, :get_by_name}, "Joey", select: [:name], format: :raw)
+
+      # No matching results
+      assert [] == DB.all({:friends, :get_by_name}, "Michael Scott", format: :type)
     end
   end
 

--- a/test/db/db_test.exs
+++ b/test/db/db_test.exs
@@ -462,20 +462,20 @@ defmodule Feeb.DBTest do
       assert ["i_am_atom", 50] == DB.one({:all_types, :get_atom_and_integer}, [], format: :raw)
       assert ["{\"foo\":\"bar\"}"] == DB.one({:all_types, :get_map_keys_atom}, [], format: :raw)
 
-      # With the :type flag, we return the values formatted by their types _without_ the full schema
+      # With the :map flag, we return the values formatted by their types _without_ the full schema
       assert %{map_keys_atom: %{foo: "bar"}} ==
-               DB.one({:all_types, :get_map_keys_atom}, [], format: :type)
+               DB.one({:all_types, :get_map_keys_atom}, [], format: :map)
 
       assert %{atom: :i_am_atom, integer: 50} ==
-               DB.one({:all_types, :get_atom_and_integer}, [], format: :type)
+               DB.one({:all_types, :get_atom_and_integer}, [], format: :map)
 
       # Custom selection with different formats
       assert ["Phoebe"] = DB.one({:friends, :fetch}, [1], select: [:name], format: :raw)
-      assert %{name: "Phoebe"} = DB.one({:friends, :fetch}, [1], select: [:name], format: :type)
+      assert %{name: "Phoebe"} = DB.one({:friends, :fetch}, [1], select: [:name], format: :map)
 
       # No matching results
       assert nil == DB.one({:friends, :fetch}, [500], select: [:name], format: :raw)
-      assert nil == DB.one({:friends, :fetch}, [500], select: [:name], format: :type)
+      assert nil == DB.one({:friends, :fetch}, [500], select: [:name], format: :map)
     end
 
     test "works with window functions when using :raw flag", %{shard_id: shard_id} do
@@ -583,21 +583,21 @@ defmodule Feeb.DBTest do
       assert [["{\"foo\":\"bar\"}"], ["{\"girl\":[\"so\",\"confusing\"]}"]] |> Enum.sort() ==
                DB.all({:all_types, :get_map}, [], format: :raw) |> Enum.sort()
 
-      # With the :type flag, we return the values formatted by their types _without_ the full schema
+      # With the :map flag, we return the values formatted by their types _without_ the full schema
       assert [%{map: %{girl: ["so", "confusing"]}}, %{map: %{foo: "bar"}}] |> Enum.sort() ==
-               DB.all({:all_types, :get_map}, [], format: :type) |> Enum.sort()
+               DB.all({:all_types, :get_map}, [], format: :map) |> Enum.sort()
 
       assert [%{atom: :i_am_atom, integer: 50}, %{atom: :other_atom, integer: -2}] |> Enum.sort() ==
-               DB.all({:all_types, :get_atom_and_integer}, [], format: :type) |> Enum.sort()
+               DB.all({:all_types, :get_atom_and_integer}, [], format: :map) |> Enum.sort()
 
       # Custom selection with different formats
       assert [%{name: "Phoebe"}] =
-               DB.all({:friends, :get_by_name}, "Phoebe", select: [:name], format: :type)
+               DB.all({:friends, :get_by_name}, "Phoebe", select: [:name], format: :map)
 
       assert [["Joey"]] = DB.all({:friends, :get_by_name}, "Joey", select: [:name], format: :raw)
 
       # No matching results
-      assert [] == DB.all({:friends, :get_by_name}, "Michael Scott", format: :type)
+      assert [] == DB.all({:friends, :get_by_name}, "Michael Scott", format: :map)
     end
   end
 

--- a/test/db/query_test.exs
+++ b/test/db/query_test.exs
@@ -1,7 +1,7 @@
 defmodule Feeb.DB.QueryTest do
   # Reason for `async: false`: this test suite interacts directly with the compiled queries cache.
   # While it's technically possible to adapt the cache to be per-test, I don't think it's worth the
-  # added complexity. As such, I'd rather have this test suite run separately from the rest.
+  # added complexity. As such, I'd rather have this test suite running separately from the rest.
   use ExUnit.Case, async: false
   import ExUnit.CaptureLog
 
@@ -111,6 +111,17 @@ defmodule Feeb.DB.QueryTest do
       assert target_fields == [:quantity, :price]
       assert bindings == [:order_id, :product_id]
       assert query_type == :select
+    end
+
+    test ":__fetch - raises when invalid fields are selected" do
+      Query.compile(@order_items_path, {:test, :order_items})
+
+      %{message: error} =
+        assert_raise RuntimeError, fn ->
+          Query.get_templated_query_id({:test, :order_items, :__fetch}, [:i_dont_exist])
+        end
+
+      assert error =~ "Can't select :i_dont_exist; not a valid field for Elixir.Sample.OrderItems"
     end
 
     test ":__fetch - raises when schema has no PK" do


### PR DESCRIPTION
Now you no longer have to always `SELECT *`, you can fetch a subset of the entire row with an API that looks like this:

```elixir
DB.one({:invoices, :fetch}, [1], select: [:id, :total])

DB.all(Invoice, [], select: [:id, :total])
```

Future improvements (still in the scope of this PR):

- [x] Make sure custom selection works for user-defined queries (not only templated queries)
- [x] Expand coverage to include `format: :type`
- [x] Figure out a better name for `format: :type`. Maybe `format: :map` or `format: :subset`?

IMO user-defined queries should almost always `SELECT *` and have their selection narrowed at runtime via adhoc queries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting specific fields when fetching or inserting data, allowing users to customize which fields are returned in query results.
  - Introduced dynamic query compilation to support ad-hoc queries with custom selected fields.
  - Added a new query to filter records by integer values.

- **Bug Fixes**
  - Improved handling of partially loaded data, with unselected fields now returned as not loaded.

- **Tests**
  - Expanded test coverage for custom field selection and composite primary keys to ensure correct behavior with new selection features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->