### PR TITLE
Allow Enum values to be defined as a function

### DIFF
--- a/lib/feeb/db/type/enum.ex
+++ b/lib/feeb/db/type/enum.ex
@@ -9,13 +9,19 @@ defmodule Feeb.DB.Type.Enum do
   If a valid `format` is specified, keep as is. However, if one was not specified by the user, infer
   it based on the contents of the `values` entry. We assume all entries within `values` will share
   the same type (and we will crash otherwise).
+
+  We accept `values` being a function, as long as it is a function that returns a list. This might
+  be useful if the application wants to avoid transitive compile-time dependencies.
   """
+  def overwrite_opts(%{values: values_fn} = opts, mod, identifier) when is_function(values_fn),
+    do: overwrite_opts(%{opts | values: values_fn.()}, mod, identifier)
+
   def overwrite_opts(%{format: format} = opts, _, _) do
     true = format in [:atom, :safe_atom, :string]
     opts
   end
 
-  def overwrite_opts(%{values: values} = opts, _, identifier) do
+  def overwrite_opts(%{values: values} = opts, _, identifier) when is_list(values) do
     value_types =
       values
       |> Enum.map(fn value ->

--- a/priv/test/migrations/test/241020150400_all_types.sql
+++ b/priv/test/migrations/test/241020150400_all_types.sql
@@ -30,5 +30,6 @@ CREATE TABLE all_types (
   list_nullable TEXT,
   enum TEXT,
   enum_nullable TEXT,
-  enum_safe_atom TEXT
+  enum_safe_atom TEXT,
+  enum_fn TEXT
 ) STRICT;

--- a/test/db/schema_test.exs
+++ b/test/db/schema_test.exs
@@ -59,7 +59,8 @@ defmodule DB.SchemaTest do
                :list_nullable,
                :enum,
                :enum_nullable,
-               :enum_safe_atom
+               :enum_safe_atom,
+               :enum_fn
              ] == AllTypes.__cols__()
     end
   end

--- a/test/support/db/schemas/all_types.ex
+++ b/test/support/db/schemas/all_types.ex
@@ -36,6 +36,7 @@ defmodule Sample.AllTypes do
     {:enum, {:enum, values: [:one, :two, :three]}},
     {:enum_nullable, {:enum, values: ["foo", "bar", "baz"], nullable: true}},
     {:enum_safe_atom, {:enum, values: [:safe, :atom], format: :safe_atom, nullable: true}},
+    {:enum_fn, {:enum, values: fn -> [:from, :a, :function] end, nullable: true}},
     {:virtual, {:integer, virtual: true}},
     {:virtual_with_after_read, {:integer, virtual: true, after_read: :load_virtual_integer}}
   ]


### PR DESCRIPTION
This might be useful for applications that wish to avoid transitive compile-time dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for defining enum values using a function that returns a list, enabling dynamic value generation.
  - Introduced a new enum field that leverages this dynamic value capability.

- **Bug Fixes**
  - None.

- **Tests**
  - Expanded test coverage to verify correct handling, storage, and retrieval of enum fields defined with dynamic values.
  - Added tests to ensure the new enum field is correctly processed in schema and database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->