### PR TITLE
Add `app.config` requirement to Mix tasks

### DIFF
--- a/lib/mix/task/feeb_db/dump_schemas.ex
+++ b/lib/mix/task/feeb_db/dump_schemas.ex
@@ -2,6 +2,8 @@ defmodule Mix.Tasks.FeebDb.DumpSchemas do
   use Mix.Task
   alias Feeb.DB.{Migrator, SQLite}
 
+  @requirements ["app.config"]
+
   # TODO: Get these paths from args instead of hard-coding them here
   @tmp_db "/tmp/helix_tmp_dump.db"
   @output_path "priv/schemas"

--- a/lib/mix/task/feeb_db/gen/migration.ex
+++ b/lib/mix/task/feeb_db/gen/migration.ex
@@ -3,6 +3,8 @@ defmodule Mix.Tasks.FeebDb.Gen.Migration do
   require Logger
   alias Feeb.DB.Config
 
+  @requirements ["app.config"]
+
   @file_adapter Application.compile_env(:feebdb, :adapters)[:file] || Feeb.Adapters.File
 
   @option_parser_opts [

--- a/lib/mix/task/feeb_db/gen/query.ex
+++ b/lib/mix/task/feeb_db/gen/query.ex
@@ -3,6 +3,8 @@ defmodule Mix.Tasks.FeebDb.Gen.Query do
   require Logger
   alias Feeb.DB.Config
 
+  @requirements ["app.config"]
+
   @file_adapter Application.compile_env(:feebdb, :adapters)[:file] || Feeb.Adapters.File
 
   @option_parser_opts [

--- a/lib/mix/task/feeb_db/migrate.ex
+++ b/lib/mix/task/feeb_db/migrate.ex
@@ -3,6 +3,8 @@ defmodule Mix.Tasks.FeebDb.Migrate do
   require Logger
   alias Feeb.DB.{Boot, Repo}
 
+  @requirements ["app.config"]
+
   @impl Mix.Task
   def run(_args) do
     Repo.Manager.Supervisor.start_link([])


### PR DESCRIPTION
This supports applications defining contexts in the `config/runtime.exs` file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured database schema dump and migration tasks automatically load application configuration before execution, preventing failures due to missing settings.
  * Improved reliability of running these tasks across environments by enforcing the required configuration load step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->