### PR TITLE
Support inequality operators when parsing queries

### DIFF
--- a/lib/feeb/db/query/binding.ex
+++ b/lib/feeb/db/query/binding.ex
@@ -42,12 +42,12 @@ defmodule Feeb.DB.Query.Binding do
 
   defp parse_kv(sql) do
     sql
-    |> String.split(" = ?")
+    |> String.split(" ?")
     |> List.delete_at(-1)
     |> Enum.map(fn expr ->
       expr
       |> String.split(" ")
-      |> Enum.at(-1)
+      |> Enum.at(-2)
       |> String.to_atom()
     end)
   end

--- a/test/db/query/binding_test.exs
+++ b/test/db/query/binding_test.exs
@@ -1,0 +1,20 @@
+defmodule Feeb.DB.Query.BindingTest do
+  use ExUnit.Case, async: true
+
+  alias Feeb.DB.Query.Binding
+
+  describe "parse_params/3" do
+    test "returns the expected params bindings (SELECT)" do
+      [
+        {"select * from users where id = ?;", [:id]},
+        {"select * from users where id = ? and name = ?;", [:id, :name]},
+        {"select * from users where inserted_at >= ?", [:inserted_at]},
+        {"select * from foo where id > ? and id < ?", [:id, :id]},
+        {"select * from foo where bar <= ? or id = ?", [:bar, :id]}
+      ]
+      |> Enum.each(fn {sql, expected_bindings} ->
+        assert expected_bindings == Binding.parse_params(:select, sql, [])
+      end)
+    end
+  end
+end


### PR DESCRIPTION
Very rudimentary but works great so far :white_check_mark: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parsing of key-value bindings in SQL statements, ensuring parameters map to the correct fields and improving reliability for SELECT queries with single or multiple placeholders.
* **Tests**
  * Added comprehensive automated tests for parameter binding across multiple SELECT query cases to improve coverage and prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->