### PR TITLE
Add support for @fields atstring

### DIFF
--- a/lib/feeb/db/query.ex
+++ b/lib/feeb/db/query.ex
@@ -394,6 +394,13 @@ defmodule Feeb.DB.Query do
   defp add_query_type(qt, line, qs, id, {sql, bindings, nil}),
     do: handle_line(line, qs, id, {sql, bindings, qt})
 
+  # @fields atstring: Matching on "fields ["
+  defp handle_atstring(<<102, 105, 101, 108, 100, 115, 32, 91, raw_bindings::binary>>, qs, id, q) do
+    {sql, {_prev_field_bindings, params_bindings}, qt} = q
+    field_bindings = Binding.parse_atstring(raw_bindings)
+    {qs, id, {sql, {field_bindings, params_bindings}, qt}}
+  end
+
   # @bind atstring: Matching on "bind ["
   defp handle_atstring(<<98, 105, 110, 100, 32, 91, raw_bindings::binary>>, qs, id, q) do
     {sql, {field_bindings, prev_params_bindings}, qt} = q

--- a/lib/feeb/db/query/binding.ex
+++ b/lib/feeb/db/query/binding.ex
@@ -20,6 +20,9 @@ defmodule Feeb.DB.Query.Binding do
     parse_comma_separated(raw_fields)
   end
 
+  # If explicit field bindings were provided via `-- @fields`, use them
+  def parse_fields(_qt, _sql, [_ | _] = bindings), do: bindings
+
   def parse_fields(:select, sql, []) do
     [raw_fields | _] =
       sql

--- a/priv/test/queries/test/chaos.sql
+++ b/priv/test/queries/test/chaos.sql
@@ -33,3 +33,9 @@ DELETE FROM accounts WHERE id = ? AND email = ?;
 -- @bind [:acc_id, :email_address]
 -- :delete2
 DELETE FROM accounts WHERE id = ? AND email = ?;
+
+-- @fields [:*]
+-- :get_with_join
+SELECT a.* FROM accounts a
+JOIN users u ON a.id = u.account_id
+WHERE u.id = ?;

--- a/test/db/query/binding_test.exs
+++ b/test/db/query/binding_test.exs
@@ -16,5 +16,44 @@ defmodule Feeb.DB.Query.BindingTest do
         assert expected_bindings == Binding.parse_params(:select, sql, [])
       end)
     end
+
+    test "returns explicit bindings when provided" do
+      sql = "select * from users where id = ?;"
+      explicit_bindings = [:user_id]
+      assert explicit_bindings == Binding.parse_params(:select, sql, explicit_bindings)
+    end
+  end
+
+  describe "parse_fields/3" do
+    test "returns [:*] for SELECT * queries" do
+      assert [:*] == Binding.parse_fields(:select, "select * from users;", [])
+    end
+
+    test "returns parsed fields for explicit column selection" do
+      sql = "select id, name, email from users;"
+      assert [:id, :name, :email] == Binding.parse_fields(:select, sql, [])
+    end
+
+    test "returns explicit bindings when provided (for JOIN queries)" do
+      # When using table aliases like `SELECT c.*`, the parser returns `:"c.*"` which is
+      # incorrect. The `@fields` annotation allows overriding this behavior.
+      sql = "select c.* from chains c join chain_tunnels ct on c.id = ct.chain_id;"
+      explicit_bindings = [:*]
+      assert explicit_bindings == Binding.parse_fields(:select, sql, explicit_bindings)
+    end
+
+    test "returns empty list for non-SELECT queries" do
+      assert [] == Binding.parse_fields(:insert, "insert into users (id) values (?);", [])
+      assert [] == Binding.parse_fields(:update, "update users set name = ?;", [])
+      assert [] == Binding.parse_fields(:delete, "delete from users where id = ?;", [])
+    end
+  end
+
+  describe "parse_atstring/1" do
+    test "parses field bindings" do
+      assert [:*] == Binding.parse_atstring("*]")
+      assert [:id, :name] == Binding.parse_atstring("id, name]")
+      assert [:foo, :bar, :baz] == Binding.parse_atstring("foo, bar, baz]")
+    end
   end
 end

--- a/test/db/query_test.exs
+++ b/test/db/query_test.exs
@@ -29,7 +29,8 @@ defmodule Feeb.DB.QueryTest do
         :update_password,
         :update_password2,
         :delete,
-        :delete2
+        :delete2,
+        :get_with_join
       ]
       |> Enum.each(fn query_name ->
         assert_chaos_query(query_name, Query.fetch!({:test, :chaos, query_name}))
@@ -339,6 +340,15 @@ defmodule Feeb.DB.QueryTest do
     assert fields_b == []
     assert params_b == [:acc_id, :email_address]
     assert qt == :delete
+  end
+
+  defp assert_chaos_query(:get_with_join, query) do
+    {sql, {fields_b, params_b}, qt} = query
+    assert sql == "select a.* from accounts a join users u on a.id = u.account_id where u.id = ?;"
+    # The @fields annotation overrides the default parsing which would return `[:"a.*"]`
+    assert fields_b == [:*]
+    assert params_b == [:"u.id"]
+    assert qt == :select
   end
 
   defp erase_all_query_caches do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicit field binding directives in SQL queries, allowing users to specify which fields should be extracted, particularly beneficial for complex JOIN scenarios with aliased tables.

* **Tests**
  * Added comprehensive test coverage for field binding parsing, including wildcard selections, explicit column lists, and edge cases across different query types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->